### PR TITLE
Add basic Electron app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # home_chores
-Deal with your own chores with a point based system 
+
+Deal with your own chores with a point based system.
+
+This repository now includes a minimal [Electron](https://www.electronjs.org/) setup.
+
+## Getting Started
+
+Install dependencies (requires Node.js and npm):
+
+```bash
+npm install
+```
+
+To run the application:
+
+```bash
+npm start
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Hello Electron</title>
+  </head>
+  <body>
+    <h1>Welcome to your Electron App!</h1>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,28 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "home_chores",
+  "version": "1.0.0",
+  "description": "Deal with your own chores with a point based system",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "devDependencies": {
+    "electron": "^29.0.0"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,2 @@
+// This file can be used to expose functionality to the renderer
+// process via the contextBridge API.


### PR DESCRIPTION
## Summary
- set up a minimal Electron application with `main.js`, `index.html` and `preload.js`
- define npm scripts and dependency in `package.json`
- document how to run the app in `README`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862f0c4b8d0832faf38a3f355f3c8fe