### PR TITLE
Add express backend and simple task UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+db.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Deal with your own chores with a point based system.
 
-This repository now includes a minimal [Electron](https://www.electronjs.org/) setup.
+This repository now includes a minimal [Electron](https://www.electronjs.org/) setup with a small Express backend.
 
 ## Getting Started
 
@@ -17,3 +17,5 @@ To run the application:
 ```bash
 npm start
 ```
+
+The application will start an Express server on `http://localhost:3000` to store tasks in a local JSON file.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,18 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>Hello Electron</title>
+    <title>Home Chores</title>
   </head>
   <body>
-    <h1>Welcome to your Electron App!</h1>
+    <h1>Task Manager</h1>
+    <form id="taskForm">
+      <input type="text" id="name" placeholder="Task name" required />
+      <input type="text" id="assignedTo" placeholder="Assigned to" required />
+      <input type="date" id="dueDate" required />
+      <input type="number" id="points" placeholder="Points" required />
+      <button type="submit">Add Task</button>
+    </form>
+    <ul id="taskList"></ul>
+    <script src="renderer.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow } = require('electron');
+require('./server');
 const path = require('path');
 
 function createWindow () {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,10 @@
   },
   "devDependencies": {
     "electron": "^29.0.0"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "lowdb": "^6.0.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,30 @@
+async function loadTasks() {
+  const res = await fetch('http://localhost:3000/tasks');
+  const tasks = await res.json();
+  const list = document.getElementById('taskList');
+  list.innerHTML = '';
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = `${t.name} - ${t.assignedTo} - due ${t.dueDate} - ${t.points} points`;
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('taskForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    name: document.getElementById('name').value,
+    assignedTo: document.getElementById('assignedTo').value,
+    dueDate: document.getElementById('dueDate').value,
+    points: document.getElementById('points').value
+  };
+  await fetch('http://localhost:3000/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  e.target.reset();
+  loadTasks();
+});
+
+window.addEventListener('DOMContentLoaded', loadTasks);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const { Low, JSONFile } = require('lowdb');
+const { v4: uuidv4 } = require('uuid');
+const path = require('path');
+
+const app = express();
+const dbFile = path.join(__dirname, 'db.json');
+const adapter = new JSONFile(dbFile);
+const db = new Low(adapter);
+
+async function initDb() {
+  await db.read();
+  db.data ||= { tasks: [] };
+  await db.write();
+}
+
+initDb();
+
+app.use(express.json());
+
+app.get('/tasks', async (req, res) => {
+  await db.read();
+  res.json(db.data.tasks);
+});
+
+app.post('/tasks', async (req, res) => {
+  const { name, assignedTo, dueDate, points } = req.body;
+  if (!name) return res.status(400).json({ error: 'name required' });
+  const task = {
+    id: uuidv4(),
+    name,
+    assignedTo,
+    dueDate,
+    points: Number(points) || 0,
+    createdAt: new Date().toISOString()
+  };
+  await db.read();
+  db.data.tasks.push(task);
+  await db.write();
+  res.json(task);
+});
+
+const port = 3000;
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- create Express backend using LowDB for storing tasks
- add renderer script to interact with backend
- update Electron main file to start the backend
- add HTML form and list to manage tasks
- document new functionality and add .gitignore

## Testing
- `npm start` *(fails: Cannot find module 'electron')*

------
https://chatgpt.com/codex/tasks/task_e_6862f4c45b34832faf82f11157f30034