### PR TITLE
Fix AddTask CORS issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cors = require('cors');
 const path = require('path');
 
 const app = express();
@@ -14,6 +15,7 @@ const app = express();
   await db.write();
 
   app.use(express.json());
+  app.use(cors());
 
   require('./routes')(app, db);
 


### PR DESCRIPTION
## Summary
- enable CORS in the Express server so `POST /tasks` works from the renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68696aa9a790832f847457617f3b64b9