### PR TITLE
Introduce basic SPA routing

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -7,21 +7,17 @@ const {
     ListItem,
     ListItemText
 } = MaterialUI;
+const {
+    BrowserRouter,
+    Routes,
+    Route,
+    Link,
+    Navigate,
+    useNavigate
+} = ReactRouterDOM;
 
-function App() {
-    const [tasks, setTasks] = useState([]);
-
-    const loadTasks = async () => {
-        const res = await fetch('http://localhost:3000/tasks');
-        const data = await res.json();
-        setTasks(data);
-    };
-
-    useEffect(() => {
-        console.log('Form listener registered');
-        loadTasks();
-    }, []);
-
+function TaskCreate() {
+    const navigate = useNavigate();
     const handleSubmit = async (e) => {
         e.preventDefault();
         const form = e.target;
@@ -37,23 +33,63 @@ function App() {
             body: JSON.stringify(data)
         });
         form.reset();
-        loadTasks();
+        navigate('/list');
     };
-
     return (
         React.createElement(Container, {maxWidth: 'sm'},
-            React.createElement('h1', null, 'Task Manager'),
+            React.createElement('h1', null, 'Create Task'),
             React.createElement('form', {id: 'taskForm', onSubmit: handleSubmit},
                 React.createElement(TextField, {label: 'Task name', name: 'name', required: true, fullWidth: true, margin: 'normal'}),
                 React.createElement(TextField, {label: 'Assigned to', name: 'assignedTo', required: true, fullWidth: true, margin: 'normal'}),
                 React.createElement(TextField, {label: 'Due date', name: 'dueDate', type: 'date', InputLabelProps: {shrink: true}, required: true, fullWidth: true, margin: 'normal'}),
                 React.createElement(TextField, {label: 'Points', name: 'points', type: 'number', required: true, fullWidth: true, margin: 'normal'}),
                 React.createElement(Button, {type: 'submit', variant: 'contained', color: 'primary', style: {marginTop: '16px'}}, 'Add Task')
-            ),
+            )
+        )
+    );
+}
+
+function TaskList() {
+    const [tasks, setTasks] = useState([]);
+    const loadTasks = async () => {
+        const res = await fetch('http://localhost:3000/tasks');
+        const data = await res.json();
+        setTasks(data);
+    };
+    useEffect(() => { loadTasks(); }, []);
+    return (
+        React.createElement(Container, {maxWidth: 'sm'},
+            React.createElement('h1', null, 'Task List'),
             React.createElement(List, {id: 'taskList'},
                 tasks.map(t => React.createElement(ListItem, {key: t.id},
                     React.createElement(ListItemText, {primary: `${t.name} - ${t.assignedTo}`, secondary: `due ${t.dueDate} - ${t.points} points`})
                 ))
+            )
+        )
+    );
+}
+
+function App() {
+    return (
+        React.createElement(BrowserRouter, null,
+            React.createElement('div', {style: {display: 'flex'}},
+                React.createElement('div', {style: {flex: 1, paddingRight: '16px'}},
+                    React.createElement(Routes, null,
+                        React.createElement(Route, {path: '/create', element: React.createElement(TaskCreate)}),
+                        React.createElement(Route, {path: '/list', element: React.createElement(TaskList)}),
+                        React.createElement(Route, {path: '*', element: React.createElement(Navigate, {to: '/create'})})
+                    )
+                ),
+                React.createElement('nav', {style: {width: '200px', borderLeft: '1px solid #ccc', paddingLeft: '16px'}},
+                    React.createElement(List, null,
+                        React.createElement(ListItem, null,
+                            React.createElement(Link, {to: '/create'}, 'Create Task')
+                        ),
+                        React.createElement(ListItem, null,
+                            React.createElement(Link, {to: '/list'}, 'Task List')
+                        )
+                    )
+                )
             )
         )
     );

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 <script src="https://unpkg.com/@emotion/react@11/dist/emotion-react.umd.min.js"></script>
 <script src="https://unpkg.com/@emotion/styled@11/dist/emotion-styled.umd.min.js"></script>
 <script src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
+<script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
 <script src="app.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `react-router-dom` via CDN
- split tasks into Create and List pages
- add right-hand nav for navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686974c392d8832fb79d992818696052