### PR TITLE
Implement simple routing without react-router-dom

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
 <script src="https://unpkg.com/@emotion/react@11/dist/emotion-react.umd.min.js"></script>
 <script src="https://unpkg.com/@emotion/styled@11/dist/emotion-styled.umd.min.js"></script>
 <script src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
-<script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
 <script src="app.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove external React Router dependency from index.html
- implement minimal hash-based routing logic in `app.jsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697ae140c8832fb1cc9e2713378bd6