### PR TITLE
Refactor frontend into separate components

### DIFF
--- a/NavigationBar.jsx
+++ b/NavigationBar.jsx
@@ -1,0 +1,17 @@
+const { List, ListItem } = MaterialUI;
+
+function NavigationBar() {
+    const navigate = useNavigate();
+    return (
+        React.createElement('nav', {style: {width: '200px', borderLeft: '1px solid #ccc', paddingLeft: '16px'}},
+            React.createElement(List, null,
+                React.createElement(ListItem, null,
+                    React.createElement('a', {href: '#create', onClick: () => navigate('create')}, 'Create Task')
+                ),
+                React.createElement(ListItem, null,
+                    React.createElement('a', {href: '#list', onClick: () => navigate('list')}, 'Task List')
+                )
+            )
+        )
+    );
+}

--- a/TaskCreate.jsx
+++ b/TaskCreate.jsx
@@ -1,0 +1,34 @@
+const { Container, TextField, Button } = MaterialUI;
+
+function TaskCreate() {
+    const navigate = useNavigate();
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const data = {
+            name: form.name.value,
+            assignedTo: form.assignedTo.value,
+            dueDate: form.dueDate.value,
+            points: form.points.value
+        };
+        await fetch('http://localhost:3000/tasks', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        form.reset();
+        navigate('list');
+    };
+    return (
+        React.createElement(Container, {maxWidth: 'sm'},
+            React.createElement('h1', null, 'Create Task'),
+            React.createElement('form', {id: 'taskForm', onSubmit: handleSubmit},
+                React.createElement(TextField, {label: 'Task name', name: 'name', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(TextField, {label: 'Assigned to', name: 'assignedTo', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(TextField, {label: 'Due date', name: 'dueDate', type: 'date', InputLabelProps: {shrink: true}, required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(TextField, {label: 'Points', name: 'points', type: 'number', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(Button, {type: 'submit', variant: 'contained', color: 'primary', style: {marginTop: '16px'}}, 'Add Task')
+            )
+        )
+    );
+}

--- a/TaskList.jsx
+++ b/TaskList.jsx
@@ -1,0 +1,21 @@
+const { Container, List, ListItem, ListItemText } = MaterialUI;
+
+function TaskList() {
+    const [tasks, setTasks] = React.useState([]);
+    const loadTasks = async () => {
+        const res = await fetch('http://localhost:3000/tasks');
+        const data = await res.json();
+        setTasks(data);
+    };
+    React.useEffect(() => { loadTasks(); }, []);
+    return (
+        React.createElement(Container, {maxWidth: 'sm'},
+            React.createElement('h1', null, 'Task List'),
+            React.createElement(List, {id: 'taskList'},
+                tasks.map(t => React.createElement(ListItem, {key: t.id},
+                    React.createElement(ListItemText, {primary: `${t.name} - ${t.assignedTo}`, secondary: `due ${t.dueDate} - ${t.points} points`})
+                ))
+            )
+        )
+    );
+}

--- a/app.jsx
+++ b/app.jsx
@@ -1,12 +1,4 @@
 const { useState, useEffect } = React;
-const {
-    Container,
-    TextField,
-    Button,
-    List,
-    ListItem,
-    ListItemText
-} = MaterialUI;
 
 // Simple hash-based navigation to avoid external router dependency
 const NavigationContext = React.createContext({
@@ -39,61 +31,9 @@ function useNavigate() {
     return React.useContext(NavigationContext).navigate;
 }
 
-function TaskCreate() {
-    const navigate = useNavigate();
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        const form = e.target;
-        const data = {
-            name: form.name.value,
-            assignedTo: form.assignedTo.value,
-            dueDate: form.dueDate.value,
-            points: form.points.value
-        };
-        await fetch('http://localhost:3000/tasks', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(data)
-        });
-        form.reset();
-        navigate('list');
-    };
-    return (
-        React.createElement(Container, {maxWidth: 'sm'},
-            React.createElement('h1', null, 'Create Task'),
-            React.createElement('form', {id: 'taskForm', onSubmit: handleSubmit},
-                React.createElement(TextField, {label: 'Task name', name: 'name', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Assigned to', name: 'assignedTo', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Due date', name: 'dueDate', type: 'date', InputLabelProps: {shrink: true}, required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Points', name: 'points', type: 'number', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(Button, {type: 'submit', variant: 'contained', color: 'primary', style: {marginTop: '16px'}}, 'Add Task')
-            )
-        )
-    );
-}
-
-function TaskList() {
-    const [tasks, setTasks] = useState([]);
-    const loadTasks = async () => {
-        const res = await fetch('http://localhost:3000/tasks');
-        const data = await res.json();
-        setTasks(data);
-    };
-    useEffect(() => { loadTasks(); }, []);
-    return (
-        React.createElement(Container, {maxWidth: 'sm'},
-            React.createElement('h1', null, 'Task List'),
-            React.createElement(List, {id: 'taskList'},
-                tasks.map(t => React.createElement(ListItem, {key: t.id},
-                    React.createElement(ListItemText, {primary: `${t.name} - ${t.assignedTo}`, secondary: `due ${t.dueDate} - ${t.points} points`})
-                ))
-            )
-        )
-    );
-}
 
 function App() {
-    const { page, navigate } = React.useContext(NavigationContext);
+    const { page } = React.useContext(NavigationContext);
     return (
         React.createElement('div', {style: {display: 'flex'}},
             React.createElement('div', {style: {flex: 1, paddingRight: '16px'}},
@@ -101,16 +41,7 @@ function App() {
                     React.createElement(TaskCreate) :
                     React.createElement(TaskList)
             ),
-            React.createElement('nav', {style: {width: '200px', borderLeft: '1px solid #ccc', paddingLeft: '16px'}},
-                React.createElement(List, null,
-                    React.createElement(ListItem, null,
-                        React.createElement('a', {href: '#create', onClick: () => navigate('create')}, 'Create Task')
-                    ),
-                    React.createElement(ListItem, null,
-                        React.createElement('a', {href: '#list', onClick: () => navigate('list')}, 'Task List')
-                    )
-                )
-            )
+            React.createElement(NavigationBar)
         )
     );
 }

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 <script src="https://unpkg.com/@emotion/react@11/dist/emotion-react.umd.min.js"></script>
 <script src="https://unpkg.com/@emotion/styled@11/dist/emotion-styled.umd.min.js"></script>
 <script src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
+<script src="NavigationBar.jsx"></script>
+<script src="TaskCreate.jsx"></script>
+<script src="TaskList.jsx"></script>
 <script src="app.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- break out `TaskCreate`, `TaskList` and `NavigationBar` components into their own files
- update `App` component to use `NavigationBar`
- load new component files from `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697f36cc24832fb447ac09795fe0b5