### PR TITLE
Fix MUI globals and switch to React 18 root

### DIFF
--- a/NavigationBar.jsx
+++ b/NavigationBar.jsx
@@ -1,14 +1,14 @@
-const { List, ListItem } = MaterialUI;
+// Access Material UI components directly from the global MaterialUI object
 
 function NavigationBar() {
     const navigate = useNavigate();
     return (
         React.createElement('nav', {style: {width: '200px', borderLeft: '1px solid #ccc', paddingLeft: '16px'}},
-            React.createElement(List, null,
-                React.createElement(ListItem, null,
+            React.createElement(MaterialUI.List, null,
+                React.createElement(MaterialUI.ListItem, null,
                     React.createElement('a', {href: '#create', onClick: () => navigate('create')}, 'Create Task')
                 ),
-                React.createElement(ListItem, null,
+                React.createElement(MaterialUI.ListItem, null,
                     React.createElement('a', {href: '#list', onClick: () => navigate('list')}, 'Task List')
                 )
             )

--- a/TaskCreate.jsx
+++ b/TaskCreate.jsx
@@ -1,4 +1,4 @@
-const { Container, TextField, Button } = MaterialUI;
+// Access Material UI components directly from the global MaterialUI object
 
 function TaskCreate() {
     const navigate = useNavigate();
@@ -20,14 +20,14 @@ function TaskCreate() {
         navigate('list');
     };
     return (
-        React.createElement(Container, {maxWidth: 'sm'},
+        React.createElement(MaterialUI.Container, {maxWidth: 'sm'},
             React.createElement('h1', null, 'Create Task'),
             React.createElement('form', {id: 'taskForm', onSubmit: handleSubmit},
-                React.createElement(TextField, {label: 'Task name', name: 'name', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Assigned to', name: 'assignedTo', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Due date', name: 'dueDate', type: 'date', InputLabelProps: {shrink: true}, required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(TextField, {label: 'Points', name: 'points', type: 'number', required: true, fullWidth: true, margin: 'normal'}),
-                React.createElement(Button, {type: 'submit', variant: 'contained', color: 'primary', style: {marginTop: '16px'}}, 'Add Task')
+                React.createElement(MaterialUI.TextField, {label: 'Task name', name: 'name', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(MaterialUI.TextField, {label: 'Assigned to', name: 'assignedTo', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(MaterialUI.TextField, {label: 'Due date', name: 'dueDate', type: 'date', InputLabelProps: {shrink: true}, required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(MaterialUI.TextField, {label: 'Points', name: 'points', type: 'number', required: true, fullWidth: true, margin: 'normal'}),
+                React.createElement(MaterialUI.Button, {type: 'submit', variant: 'contained', color: 'primary', style: {marginTop: '16px'}}, 'Add Task')
             )
         )
     );

--- a/TaskList.jsx
+++ b/TaskList.jsx
@@ -1,4 +1,4 @@
-const { Container, List, ListItem, ListItemText } = MaterialUI;
+// Access Material UI components directly from the global MaterialUI object
 
 function TaskList() {
     const [tasks, setTasks] = React.useState([]);
@@ -9,11 +9,11 @@ function TaskList() {
     };
     React.useEffect(() => { loadTasks(); }, []);
     return (
-        React.createElement(Container, {maxWidth: 'sm'},
+        React.createElement(MaterialUI.Container, {maxWidth: 'sm'},
             React.createElement('h1', null, 'Task List'),
-            React.createElement(List, {id: 'taskList'},
-                tasks.map(t => React.createElement(ListItem, {key: t.id},
-                    React.createElement(ListItemText, {primary: `${t.name} - ${t.assignedTo}`, secondary: `due ${t.dueDate} - ${t.points} points`})
+            React.createElement(MaterialUI.List, {id: 'taskList'},
+                tasks.map(t => React.createElement(MaterialUI.ListItem, {key: t.id},
+                    React.createElement(MaterialUI.ListItemText, {primary: `${t.name} - ${t.assignedTo}`, secondary: `due ${t.dueDate} - ${t.points} points`})
                 ))
             )
         )

--- a/app.jsx
+++ b/app.jsx
@@ -46,9 +46,10 @@ function App() {
     );
 }
 
-ReactDOM.render(
+// Use the React 18 root API
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
     React.createElement(NavigationProvider, null,
         React.createElement(App)
-    ),
-    document.getElementById('root')
+    )
 );


### PR DESCRIPTION
## Summary
- avoid collisions between Material UI globals by removing shared constant declarations
- update App to use `ReactDOM.createRoot`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686980a51cc8832fa5a1978499de6092