### PR TITLE
Add user management and page

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -6,6 +6,11 @@ module.exports = (app, db) => {
     res.json(db.data.tasks);
   });
 
+  app.get('/users', async (req, res) => {
+    await db.read();
+    res.json(db.data.users);
+  });
+
   app.post('/tasks', async (req, res) => {
     const { name, assignedTo, dueDate, points } = req.body;
     if (!name) return res.status(400).json({ error: 'name required' });
@@ -21,5 +26,20 @@ module.exports = (app, db) => {
     db.data.tasks.push(task);
     await db.write();
     res.json(task);
+  });
+
+  app.post('/users', async (req, res) => {
+    const { name } = req.body;
+    if (!name) return res.status(400).json({ error: 'name required' });
+    const user = {
+      id: uuidv4(),
+      name,
+      totalPoints: 0,
+      completedTasks: 0
+    };
+    await db.read();
+    db.data.users.push(user);
+    await db.write();
+    res.json(user);
   });
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,12 +10,19 @@ const app = express();
 
     const dbFile  = path.join(__dirname, 'db.json');
     const adapter = new JSONFile(dbFile);
+    const defaultUser = {
+        id: '00000000-0000-0000-0000-000000000000',
+        name: 'System User',
+        totalPoints: 0,
+        completedTasks: 0
+    };
     const defaultData = {
+        users: [defaultUser],
         tasks: [
             {
                 id: '00000000-0000-0000-0000-000000000000',
                 name: 'Test Task',
-                assignedTo: 'System',
+                assignedTo: defaultUser.id,
                 dueDate: new Date().toISOString().split('T')[0],
                 points: 0,
                 createdAt: new Date().toISOString()
@@ -25,7 +32,7 @@ const app = express();
     const db      = new Low(adapter, defaultData);
 
     await db.read();
-    db.data ||= { tasks: [] };
+    db.data ||= { tasks: [], users: [] };
     await db.write();
 
     app.use(cors());

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -4,11 +4,17 @@ import NavigationBar from './NavigationBar';
 
 function TaskList({navigate}) {
     const [tasks, setTasks] = useState([]);
+    const [users, setUsers] = useState({});
     useEffect(() => {
         const load = async () => {
             const res = await fetch('http://localhost:3000/tasks');
             const data = await res.json();
             setTasks(data);
+            const resUsers = await fetch('http://localhost:3000/users');
+            const userData = await resUsers.json();
+            const map = {};
+            userData.forEach(u => { map[u.id] = u.name; });
+            setUsers(map);
         };
         console.log('🚀 App mounted, loading tasks…');
         load();
@@ -21,7 +27,7 @@ function TaskList({navigate}) {
                 keyExtractor={(t) => t.id}
                 renderItem={({item}) => (
                     <View style={styles.item}>
-                        <Text>{item.name} - {item.assignedTo}</Text>
+                        <Text>{item.name} - {users[item.assignedTo] || item.assignedTo}</Text>
                         <Text style={styles.itemSecondary}>due {item.dueDate} - {item.points} points</Text>
                     </View>
                 )}
@@ -34,6 +40,16 @@ function TaskList({navigate}) {
 function TaskCreate({navigate}) {
     const [name, setName] = useState('');
     const [assignedTo, setAssignedTo] = useState('');
+    const [users, setUsers] = useState([]);
+    useEffect(() => {
+        const load = async () => {
+            const res = await fetch('http://localhost:3000/users');
+            const data = await res.json();
+            setUsers(data);
+            if (data.length > 0) setAssignedTo(data[0].id);
+        };
+        load();
+    }, []);
     const [dueDate, setDueDate] = useState('');
     const [points, setPoints] = useState('');
 
@@ -45,7 +61,7 @@ function TaskCreate({navigate}) {
             body: JSON.stringify(data)
         });
         setName('');
-        setAssignedTo('');
+        setAssignedTo(users[0] ? users[0].id : '');
         setDueDate('');
         setPoints('');
         navigate('list');
@@ -61,7 +77,7 @@ function TaskCreate({navigate}) {
                 style={styles.input}
             />
             <TextInput
-                placeholder="Assigned to"
+                placeholder="Assigned user ID"
                 value={assignedTo}
                 onChangeText={setAssignedTo}
                 style={styles.input}
@@ -84,6 +100,45 @@ function TaskCreate({navigate}) {
     );
 }
 
+function UsersPage({navigate}) {
+    const [users, setUsers] = useState([]);
+    const [name, setName] = useState('');
+    const load = async () => {
+        const res = await fetch('http://localhost:3000/users');
+        const data = await res.json();
+        setUsers(data);
+    };
+    useEffect(() => { load(); }, []);
+    const handleAdd = async () => {
+        await fetch('http://localhost:3000/users', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({name})
+        });
+        setName('');
+        load();
+    };
+    return (
+        <View style={styles.container}>
+            <Text style={styles.title}>Users</Text>
+            <FlatList
+                data={users}
+                keyExtractor={(u) => u.id}
+                renderItem={({item}) => (
+                    <Text>{item.name} - {item.totalPoints} pts - {item.completedTasks} tasks</Text>
+                )}
+            />
+            <TextInput
+                placeholder="User name"
+                value={name}
+                onChangeText={setName}
+                style={styles.input}
+            />
+            <Button title="Add User" onPress={handleAdd} />
+        </View>
+    );
+}
+
 export default function App() {
     const [page, setPage] = useState('create');
     const navigate = (to) => setPage(to);
@@ -93,6 +148,8 @@ export default function App() {
             <NavigationBar navigate={navigate} />
             {page === 'create' ? (
                 <TaskCreate navigate={navigate}/>
+            ) : page === 'users' ? (
+                <UsersPage navigate={navigate}/>
             ) : (
                 <TaskList navigate={navigate}/>
             )}

--- a/frontend/NavigationBar.js
+++ b/frontend/NavigationBar.js
@@ -7,6 +7,8 @@ export default function NavigationBar({ navigate }) {
             <Button title="Add Task" onPress={() => navigate('create')} />
             <View style={{height: 10}} />
             <Button title="Task List" onPress={() => navigate('list')} />
+            <View style={{height: 10}} />
+            <Button title="Users" onPress={() => navigate('users')} />
         </View>
     );
 }


### PR DESCRIPTION
## Summary
- introduce user support on the backend with `/users` routes
- store default user and assign default task to them
- allow tasks to reference users by ID
- add Users page in the frontend to list and create users
- update navigation bar with link to the user page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a9110941c832f82bb46afc63dc3fd