### PR TITLE
Add calendar view and sample data loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ node backend/server.js
 ```
 
 The backend listens on `http://localhost:3000` to store tasks in a local JSON file.  You can open the Expo URL on your mobile device to interact with the app.
+
+### Loading sample tasks
+
+A small list of example tasks is available under `backend/test_tasks.json`. These
+are **not** loaded automatically. If you want to populate the database with them
+run:
+
+```bash
+node backend/add_test_tasks.js
+```
+
+This script reads the JSON file and appends the tasks to `backend/db.json`.

--- a/backend/add_test_tasks.js
+++ b/backend/add_test_tasks.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const { Low } = await import('lowdb');
+  const { JSONFile } = await import('lowdb/node');
+  const { v4: uuidv4 } = require('uuid');
+
+  const dbFile = path.join(__dirname, 'db.json');
+  const adapter = new JSONFile(dbFile);
+  const db = new Low(adapter);
+  await db.read();
+  db.data ||= { tasks: [], users: [] };
+
+  const tasksPath = path.join(__dirname, 'test_tasks.json');
+  const tasks = JSON.parse(fs.readFileSync(tasksPath, 'utf8'));
+
+  tasks.forEach(t => {
+    db.data.tasks.push({
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      ...t
+    });
+  });
+
+  await db.write();
+  console.log(`Added ${tasks.length} test tasks`);
+})();

--- a/backend/test_tasks.json
+++ b/backend/test_tasks.json
@@ -1,0 +1,5 @@
+[
+  {"name": "Clean windows", "assignedTo": "00000000-0000-0000-0000-000000000000", "dueDate": "2024-04-20", "points": 5},
+  {"name": "Mow the lawn", "assignedTo": "00000000-0000-0000-0000-000000000000", "dueDate": "2024-04-23", "points": 8},
+  {"name": "Wash car", "assignedTo": "00000000-0000-0000-0000-000000000000", "dueDate": "2024-05-01", "points": 4}
+]

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import {View, Text, TextInput, Button, FlatList, StyleSheet} from 'react-native';
 import {Picker} from '@react-native-picker/picker';
 import NavigationBar from './NavigationBar';
+import CalendarPage from './CalendarPage';
 
 function TaskList({navigate}) {
     const [tasks, setTasks] = useState([]);
@@ -154,6 +155,8 @@ export default function App() {
                 <TaskCreate navigate={navigate}/>
             ) : page === 'users' ? (
                 <UsersPage navigate={navigate}/>
+            ) : page === 'calendar' ? (
+                <CalendarPage />
             ) : (
                 <TaskList navigate={navigate}/>
             )}

--- a/frontend/CalendarPage.js
+++ b/frontend/CalendarPage.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+
+function weekStart(date) {
+    const d = new Date(date);
+    const day = d.getDay();
+    const start = new Date(d);
+    start.setDate(d.getDate() - day); // Sunday start
+    return start.toISOString().split('T')[0];
+}
+
+export default function CalendarPage() {
+    const [tasks, setTasks] = useState([]);
+    const [view, setView] = useState('day');
+
+    useEffect(() => {
+        const load = async () => {
+            const res = await fetch('http://localhost:3000/tasks');
+            const data = await res.json();
+            setTasks(data);
+        };
+        load();
+    }, []);
+
+    const grouped = useMemo(() => {
+        const groups = {};
+        tasks.forEach(t => {
+            const due = t.dueDate || '';
+            let key = due;
+            if (view === 'week') {
+                key = weekStart(due);
+            } else if (view === 'month') {
+                key = due.slice(0, 7); // YYYY-MM
+            }
+            if (!groups[key]) groups[key] = [];
+            groups[key].push(t);
+        });
+        return Object.entries(groups).sort((a, b) => a[0].localeCompare(b[0]));
+    }, [tasks, view]);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.switcher}>
+                <Button title="Day" onPress={() => setView('day')} />
+                <Button title="Week" onPress={() => setView('week')} />
+                <Button title="Month" onPress={() => setView('month')} />
+            </View>
+            <FlatList
+                data={grouped}
+                keyExtractor={([k]) => k}
+                renderItem={({ item: [k, items] }) => (
+                    <View style={styles.group}>
+                        <Text style={styles.groupTitle}>{k}</Text>
+                        {items.map(task => (
+                            <Text key={task.id} style={styles.task}>{task.name} (due {task.dueDate})</Text>
+                        ))}
+                    </View>
+                )}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, paddingLeft: 20 },
+    switcher: { flexDirection: 'row', justifyContent: 'space-around', marginBottom: 16 },
+    group: { marginBottom: 12 },
+    groupTitle: { fontSize: 18, fontWeight: 'bold' },
+    task: { paddingLeft: 10 }
+});

--- a/frontend/NavigationBar.js
+++ b/frontend/NavigationBar.js
@@ -9,6 +9,8 @@ export default function NavigationBar({ navigate }) {
             <Button title="Task List" onPress={() => navigate('list')} />
             <View style={{height: 10}} />
             <Button title="Users" onPress={() => navigate('users')} />
+            <View style={{height: 10}} />
+            <Button title="Calendar" onPress={() => navigate('calendar')} />
         </View>
     );
 }


### PR DESCRIPTION
## Summary
- add sample tasks JSON and loader script
- document how to load sample tasks
- implement `CalendarPage` with day/week/month views
- expose calendar page through navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a956c162c832f887d0137fb05aeb1