### PR TITLE
Fix calendar rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Install dependencies (requires Node.js and npm):
 npm install
 ```
 
+If you see errors about `ViewPropTypes` being undefined when running the web
+version, make sure the optional `deprecated-react-native-prop-types` package is
+installed. It is included in `package.json` and used as a polyfill in
+`frontend/index.js`.
+
 To run the application:
 
 ```bash

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,6 +1,12 @@
 console.log('🔥 AppEntry loaded, mounting App…');
 
 import { registerRootComponent } from 'expo';
+import { View } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import App from './App';
+
+if (!View.propTypes) {
+  View.propTypes = ViewPropTypes;
+}
 
 registerRootComponent(App);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/webpack-config": "^19.0.0",
         "@react-native-picker/picker": "^2.4.10",
         "cors": "^2.8.5",
+        "deprecated-react-native-prop-types": "^4.1.0",
         "expo": "^49.0.0",
         "express": "^4.18.2",
         "lowdb": "^6.0.1",
@@ -20,8 +21,7 @@
         "react-native-calendars": "^1.130.0",
         "react-native-web": "~0.19.6",
         "uuid": "^9.0.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.10",
+    "deprecated-react-native-prop-types": "^4.1.0",
     "react-native-calendars": "^1.130.0",
     "react-native-web": "~0.19.6",
     "uuid": "^9.0.0"


### PR DESCRIPTION
## Summary
- polyfill ViewPropTypes for react-native-calendars
- note the polyfill in README
- add deprecated-react-native-prop-types dependency

## Testing
- `npm test`
- `npm run web` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686aae1144d8832f9aaa93107325ba17