### PR TITLE
Add repeating tasks and event calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Deal with your own chores with a point based system.
 
+Tasks can repeat weekly, monthly or yearly. When a task is created the server
+generates corresponding **events** for all occurrences until the optional end
+date. The calendar view displays these events rather than the raw tasks.
+
 The project now uses [React Native](https://reactnative.dev/) so the UI can run on mobile devices.  A small Express backend is still included to store tasks in a local JSON file.  The code is organized under `frontend/` and `backend/`.
 
 ## Getting Started

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -43,12 +43,14 @@ function TaskRow({item, users, refresh}) {
     const [assignedTo, setAssignedTo] = useState(item.assignedTo);
     const [dueDate, setDueDate] = useState(item.dueDate);
     const [points, setPoints] = useState(String(item.points));
+    const [repetition, setRepetition] = useState(item.repetition || 'none');
+    const [endDate, setEndDate] = useState(item.endDate || item.dueDate);
 
     const handleSave = async () => {
         await fetch(`http://localhost:3000/tasks/${item.id}`, {
             method: 'PATCH',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({name, assignedTo, dueDate, points})
+            body: JSON.stringify({name, assignedTo, dueDate, points, repetition, endDate})
         });
         setExpanded(false);
         refresh();
@@ -83,6 +85,22 @@ function TaskRow({item, users, refresh}) {
                         onChangeText={setDueDate}
                         style={styles.input}
                     />
+                    <Picker
+                        selectedValue={repetition}
+                        onValueChange={setRepetition}
+                        style={styles.input}
+                    >
+                        <Picker.Item label="No repeat" value="none" />
+                        <Picker.Item label="Weekly" value="weekly" />
+                        <Picker.Item label="Monthly" value="monthly" />
+                        <Picker.Item label="Yearly" value="yearly" />
+                    </Picker>
+                    <TextInput
+                        placeholder="End date (YYYY-MM-DD)"
+                        value={endDate}
+                        onChangeText={setEndDate}
+                        style={styles.input}
+                    />
                     <TextInput
                         placeholder="Points"
                         value={points}
@@ -112,9 +130,11 @@ function TaskCreate({navigate}) {
     }, []);
     const [dueDate, setDueDate] = useState('');
     const [points, setPoints] = useState('');
+    const [repetition, setRepetition] = useState('none');
+    const [endDate, setEndDate] = useState('');
 
     const handleSubmit = async () => {
-        const data = {name, assignedTo, dueDate, points};
+        const data = {name, assignedTo, dueDate, points, repetition, endDate};
         await fetch('http://localhost:3000/tasks', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
@@ -124,6 +144,8 @@ function TaskCreate({navigate}) {
         setAssignedTo(users[0] ? users[0].id : '');
         setDueDate('');
         setPoints('');
+        setRepetition('none');
+        setEndDate('');
         navigate('list');
     };
 
@@ -149,6 +171,22 @@ function TaskCreate({navigate}) {
                 placeholder="Due date (YYYY-MM-DD)"
                 value={dueDate}
                 onChangeText={setDueDate}
+                style={styles.input}
+            />
+            <Picker
+                selectedValue={repetition}
+                onValueChange={setRepetition}
+                style={styles.input}
+            >
+                <Picker.Item label="No repeat" value="none" />
+                <Picker.Item label="Weekly" value="weekly" />
+                <Picker.Item label="Monthly" value="monthly" />
+                <Picker.Item label="Yearly" value="yearly" />
+            </Picker>
+            <TextInput
+                placeholder="End date (YYYY-MM-DD)"
+                value={endDate}
+                onChangeText={setEndDate}
                 style={styles.input}
             />
             <TextInput

--- a/frontend/CalendarPage.js
+++ b/frontend/CalendarPage.js
@@ -4,25 +4,25 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 
 export default function CalendarPage() {
-    const [tasks, setTasks] = useState([]);
+    const [events, setEvents] = useState([]);
 
     // Daten laden
     useEffect(() => {
-        fetch('http://localhost:3000/tasks')
+        fetch('http://localhost:3000/events')
             .then(res => res.json())
-            .then(setTasks)
+            .then(setEvents)
             .catch(console.error);
     }, []);
 
     // Nach Datum gruppieren
     const itemsByDate = useMemo(() => {
-        return tasks.reduce((acc, task) => {
-            if (!task.dueDate) return acc;
-            acc[task.dueDate] = acc[task.dueDate] || [];
-            acc[task.dueDate].push(task);
+        return events.reduce((acc, ev) => {
+            if (!ev.date) return acc;
+            acc[ev.date] = acc[ev.date] || [];
+            acc[ev.date].push(ev);
             return acc;
         }, {});
-    }, [tasks]);
+    }, [events]);
 
     return (
         <div style={{ padding: 20, fontFamily: 'sans-serif' }}>
@@ -30,11 +30,10 @@ export default function CalendarPage() {
             <Calendar
                 tileContent={({ date }) => {
                     const key = date.toISOString().split('T')[0];
-                    const dayTasks = itemsByDate[key] || [];
-                    // Zeige Anzahl der Tasks oder gar nichts
-                    return dayTasks.length
+                    const dayEvents = itemsByDate[key] || [];
+                    return dayEvents.length
                         ? <span style={{ fontSize: 12, color: '#333' }}>
-                {dayTasks.length} task{dayTasks.length > 1 ? 's' : ''}
+                {dayEvents.length} event{dayEvents.length > 1 ? 's' : ''}
               </span>
                         : null;
                 }}


### PR DESCRIPTION
## Summary
- add `repetition` and `endDate` fields to tasks
- generate recurring events on the backend
- expose `/events` endpoint
- regenerate events when tasks change
- update calendar page to show events
- extend task forms with repetition controls
- document the new behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686abf2c62a4832f8268c41100b4d593