### PR TITLE
Add collapsible navigation bar

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -261,11 +261,12 @@ function UsersPage({navigate}) {
 
 export default function App() {
     const [page, setPage] = useState('create');
+    const [navOpen, setNavOpen] = useState(true);
     const navigate = (to) => setPage(to);
 
     return (
         <View style={styles.app}>
-            <NavigationBar navigate={navigate} />
+            <NavigationBar navigate={navigate} open={navOpen} setOpen={setNavOpen} />
             {page === 'create' ? (
                 <TaskCreate navigate={navigate}/>
             ) : page === 'users' ? (

--- a/frontend/NavigationBar.js
+++ b/frontend/NavigationBar.js
@@ -1,24 +1,51 @@
 import React from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { Drawer, IconButton, Tooltip } from 'react-native-paper';
 
-export default function NavigationBar({ navigate }) {
+export default function NavigationBar({ navigate, open, setOpen }) {
+    const items = [
+        {key: 'create', label: 'Add Task', icon: 'plus'},
+        {key: 'list', label: 'Task List', icon: 'format-list-bulleted'},
+        {key: 'users', label: 'Users', icon: 'account-group'},
+        {key: 'calendar', label: 'Calendar', icon: 'calendar'},
+    ];
+
     return (
-        <View style={styles.nav}>
-            <Button title="Add Task" onPress={() => navigate('create')} />
-            <View style={{height: 10}} />
-            <Button title="Task List" onPress={() => navigate('list')} />
-            <View style={{height: 10}} />
-            <Button title="Users" onPress={() => navigate('users')} />
-            <View style={{height: 10}} />
-            <Button title="Calendar" onPress={() => navigate('calendar')} />
+        <View style={[styles.nav, {width: open ? 160 : 72}]}> 
+            <IconButton
+                icon={open ? 'chevron-left' : 'chevron-right'}
+                onPress={() => setOpen(!open)}
+                style={styles.toggle}
+            />
+            <Drawer.Section style={{flex: 1}}>
+                {items.map(item => (
+                    open ? (
+                        <Drawer.Item
+                            key={item.key}
+                            label={item.label}
+                            icon={item.icon}
+                            onPress={() => navigate(item.key)}
+                        />
+                    ) : (
+                        <Tooltip key={item.key} title={item.label}>
+                            <IconButton
+                                icon={item.icon}
+                                onPress={() => navigate(item.key)}
+                            />
+                        </Tooltip>
+                    )
+                ))}
+            </Drawer.Section>
         </View>
     );
 }
 
 const styles = StyleSheet.create({
     nav: {
-        width: 160,
         padding: 10,
         backgroundColor: '#f5f5f5',
+    },
+    toggle: {
+        alignSelf: 'flex-end',
     },
 });


### PR DESCRIPTION
## Summary
- upgrade NavigationBar to use React Native Paper components
- support open/closed sidebar with tooltips when collapsed
- wire up `App` to control the navigation bar state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bbd043eec832fb3100bab36256dbc