### PR TITLE
Add time info to events with migration

### DIFF
--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,0 +1,21 @@
+const CURRENT_VERSION = 1;
+
+module.exports = async function migrate(db) {
+  await db.read();
+  db.data ||= { tasks: [], users: [], events: [] };
+  db.data.migrationVersion ||= 0;
+
+  if (db.data.migrationVersion < 1) {
+    // Add time field to events generated before version 1
+    db.data.events = db.data.events || [];
+    db.data.events.forEach(ev => {
+      if (!ev.time) {
+        const task = (db.data.tasks || []).find(t => t.id === ev.taskId);
+        const ts = task?.createdAt || new Date().toISOString();
+        ev.time = ts.split('T')[1].slice(0,5); // HH:MM
+      }
+    });
+    db.data.migrationVersion = 1;
+    await db.write();
+  }
+};

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -15,11 +15,13 @@ module.exports = (app, db) => {
     const events = [];
     let current = new Date(task.dueDate);
     const end = new Date(task.endDate || task.dueDate);
+    const time = (task.createdAt || new Date().toISOString()).split('T')[1].slice(0,5);
     while (current <= end) {
       events.push({
         id: uuidv4(),
         taskId: task.id,
-        date: current.toISOString().split('T')[0]
+        date: current.toISOString().split('T')[0],
+        time
       });
       if (task.repetition === 'weekly') {
         current.setDate(current.getDate() + 7);


### PR DESCRIPTION
## Summary
- add a migration helper that assigns a `time` field to existing events and stores a migration version
- call the migration during server start
- include event time when generating events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d88dcbaa0832faebe0921e16d5dd6