### PR TITLE
Fix calendar tile overlay positioning

### DIFF
--- a/frontend/CalendarPage.js
+++ b/frontend/CalendarPage.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { View, Text, StyleSheet, Button, useWindowDimensions } from 'react-native';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
+import './calendarOverrides.css';
 import { Calendar as BigCalendar } from 'react-native-big-calendar';
 
 export default function CalendarPage() {

--- a/frontend/calendarOverrides.css
+++ b/frontend/calendarOverrides.css
@@ -1,0 +1,3 @@
+.react-calendar__tile {
+  position: relative;
+}


### PR DESCRIPTION
## Summary
- ensure react-calendar tiles act as positioning context
- import override styles for CalendarPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687007310ebc832f96d6628cbf5509ed