### PR TITLE
Add event viewer page with editing

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -4,6 +4,7 @@ import {Card, IconButton} from 'react-native-paper';
 import NavigationBar from './NavigationBar';
 import CalendarPage from './CalendarPage';
 import TaskForm from './TaskForm';
+import EventsPage from './EventsPage';
 
 function TaskList({navigate}) {
     const [tasks, setTasks] = useState([]);
@@ -39,6 +40,7 @@ function TaskList({navigate}) {
             onEdit={task => navigate('edit', task)}
             onDuplicate={handleDuplicate}
             onDelete={handleDelete}
+            navigate={navigate}
         />
     );
 
@@ -54,7 +56,7 @@ function TaskList({navigate}) {
     );
 }
 
-function TaskRow({item, users, onEdit, onDuplicate, onDelete}) {
+function TaskRow({item, users, onEdit, onDuplicate, onDelete, navigate}) {
     return (
         <Card style={styles.card}>
             <Card.Title
@@ -64,6 +66,7 @@ function TaskRow({item, users, onEdit, onDuplicate, onDelete}) {
             <Card.Actions>
                 <IconButton icon="pencil" onPress={() => onEdit(item)} />
                 <IconButton icon="content-copy" onPress={() => onDuplicate(item.id)} />
+                <IconButton icon="calendar" onPress={() => navigate('events', item)} />
                 <IconButton icon="delete" onPress={() => onDelete(item.id)} />
             </Card.Actions>
         </Card>
@@ -114,8 +117,10 @@ export default function App() {
     const [page, setPage] = useState('create');
     const [navOpen, setNavOpen] = useState(false);
     const [editingTask, setEditingTask] = useState(null);
+    const [eventsTask, setEventsTask] = useState(null);
     const navigate = (to, param) => {
         if (to === 'edit') setEditingTask(param);
+        if (to === 'events') setEventsTask(param);
         setPage(to);
     };
 
@@ -130,6 +135,8 @@ export default function App() {
                 <UsersPage navigate={navigate}/>
             ) : page === 'calendar' ? (
                 <CalendarPage />
+            ) : page === 'events' ? (
+                <EventsPage task={eventsTask} navigate={navigate}/>
             ) : (
                 <TaskList navigate={navigate}/>
             )}

--- a/frontend/EventsPage.js
+++ b/frontend/EventsPage.js
@@ -1,0 +1,100 @@
+import React, {useEffect, useState} from 'react';
+import {View, Text, FlatList, StyleSheet, TextInput, Button} from 'react-native';
+import {Card, IconButton} from 'react-native-paper';
+import {DatePickerInput} from 'react-native-paper-dates';
+import {LOCALE} from './config';
+
+export default function EventsPage({task, navigate}) {
+    const [events, setEvents] = useState([]);
+
+    const load = async () => {
+        const res = await fetch(`http://localhost:3000/events?taskId=${task.id}`);
+        const data = await res.json();
+        setEvents(data);
+    };
+
+    useEffect(() => { load(); }, []);
+
+    const handleSave = async (id, changes) => {
+        await fetch(`http://localhost:3000/events/${id}`, {
+            method: 'PATCH',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(changes)
+        });
+        load();
+    };
+
+    const renderItem = ({item}) => (
+        <EventRow item={item} onSave={handleSave}/>
+    );
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.title}>Events for {task.name}</Text>
+            <FlatList
+                data={events}
+                keyExtractor={e => e.id}
+                renderItem={renderItem}
+            />
+            <Button title="Back to tasks" onPress={() => navigate('list')} />
+        </View>
+    );
+}
+
+function EventRow({item, onSave}) {
+    const [date, setDate] = useState(item.date);
+    const [time, setTime] = useState(item.time);
+    const [editMode, setEditMode] = useState(false);
+
+    const save = () => {
+        onSave(item.id, {date, time});
+        setEditMode(false);
+    };
+
+    return (
+        <Card style={styles.card}>
+            <Card.Title title={`${item.date} ${item.time}`} />
+            {editMode && (
+                <Card.Content>
+                    <DatePickerInput
+                        locale={LOCALE}
+                        label="Date"
+                        value={new Date(date)}
+                        onChange={d => setDate(d.toISOString().split('T')[0])}
+                        inputEnabled
+                        style={styles.input}
+                    />
+                    <TextInput
+                        value={time}
+                        onChangeText={setTime}
+                        style={styles.input}
+                        placeholder="HH:MM"
+                    />
+                </Card.Content>
+            )}
+            <Card.Actions>
+                {editMode ? (
+                    <>
+                        <Button title="Save" onPress={save} />
+                        <Button title="Cancel" onPress={() => setEditMode(false)} />
+                    </>
+                ) : (
+                    <IconButton icon="pencil" onPress={() => setEditMode(true)} />
+                )}
+            </Card.Actions>
+        </Card>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {flex: 1, padding: 20},
+    title: {fontSize: 24, marginBottom: 16},
+    card: {marginBottom: 8},
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        marginBottom: 8,
+        padding: 8,
+        borderRadius: 4,
+    }
+});


### PR DESCRIPTION
## Summary
- filter events by task on backend
- allow editing of individual events via new PATCH endpoint
- create frontend event viewer to edit events per task
- navigate to event viewer from each task card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718c7576c4832fb02e546d7c0ce5c7