### PR TITLE
Implement simple login system

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ node backend/add_test_tasks.js
 ```
 
 This script reads the JSON file and appends the tasks to `backend/db.json`.
+
+### Login
+
+Users must authenticate with a simple username/password pair.  New users are
+created with the default password `password`.  On first launch you will be asked
+to log in and can choose to remember the credentials for automatic sign in on
+subsequent launches.

--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,4 +1,4 @@
-const CURRENT_VERSION = 1;
+const CURRENT_VERSION = 2;
 
 module.exports = async function migrate(db) {
   await db.read();
@@ -16,6 +16,27 @@ module.exports = async function migrate(db) {
       }
     });
     db.data.migrationVersion = 1;
+    await db.write();
+  }
+
+  if (db.data.migrationVersion < 2) {
+    db.data.users = db.data.users || [];
+    db.data.users.forEach(u => {
+      if (u.totalPoints !== undefined && u.totalScore === undefined) {
+        u.totalScore = u.totalPoints;
+        delete u.totalPoints;
+      }
+      if (u.password === undefined) {
+        u.password = 'password';
+      }
+      if (u.completedTasks === undefined) {
+        u.completedTasks = 0;
+      }
+      if (u.totalScore === undefined) {
+        u.totalScore = 0;
+      }
+    });
+    db.data.migrationVersion = 2;
     await db.write();
   }
 };

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -176,17 +176,28 @@ module.exports = (app, db) => {
     });
 
     app.post('/users', async (req, res) => {
-        const {name} = req.body;
+        const {name, password} = req.body;
         if (!name) return res.status(400).json({error: 'name required'});
         const user = {
             id: uuidv4(),
             name,
-            totalPoints: 0,
+            password: password || 'password',
+            totalScore: 0,
             completedTasks: 0
         };
         await db.read();
         db.data.users.push(user);
         await db.write();
-        res.json(user);
+        const {password: pw, ...safeUser} = user;
+        res.json(safeUser);
+    });
+
+    app.post('/login', async (req, res) => {
+        const {name, password} = req.body;
+        await db.read();
+        const user = db.data.users.find(u => u.name === name && u.password === password);
+        if (!user) return res.status(401).json({error: 'invalid credentials'});
+        const {password: pw, ...safeUser} = user;
+        res.json(safeUser);
     });
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,11 +14,12 @@ const app = express();
     const defaultUser = {
         id: '00000000-0000-0000-0000-000000000000',
         name: 'System User',
-        totalPoints: 0,
+        password: 'password',
+        totalScore: 0,
         completedTasks: 0
     };
     const defaultData = {
-        migrationVersion: 1,
+        migrationVersion: 2,
         users: [defaultUser],
         tasks: [
             {

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -5,6 +5,7 @@ import NavigationBar from './NavigationBar';
 import CalendarPage from './CalendarPage';
 import TaskForm from './TaskForm';
 import EventsPage from './EventsPage';
+import LoginPage from './LoginPage';
 
 function TaskList({navigate}) {
     const [tasks, setTasks] = useState([]);
@@ -99,7 +100,7 @@ function UsersPage({navigate}) {
                 data={users}
                 keyExtractor={(u) => u.id}
                 renderItem={({item}) => (
-                    <Text>{item.name} - {item.totalPoints} pts - {item.completedTasks} tasks</Text>
+                    <Text>{item.name} - {item.totalScore} pts - {item.completedTasks} tasks</Text>
                 )}
             />
             <TextInput
@@ -118,11 +119,36 @@ export default function App() {
     const [navOpen, setNavOpen] = useState(false);
     const [editingTask, setEditingTask] = useState(null);
     const [eventsTask, setEventsTask] = useState(null);
+    const [user, setUser] = useState(null);
+    const [checkingLogin, setCheckingLogin] = useState(true);
+
+    useEffect(() => {
+        const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('login') : null;
+        if (!saved) { setCheckingLogin(false); return; }
+        const {name, password} = JSON.parse(saved);
+        fetch('http://localhost:3000/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({name, password})
+        })
+            .then(res => res.ok ? res.json() : null)
+            .then(u => { setUser(u); setCheckingLogin(false); })
+            .catch(() => setCheckingLogin(false));
+    }, []);
+
     const navigate = (to, param) => {
         if (to === 'edit') setEditingTask(param);
         if (to === 'events') setEventsTask(param);
         setPage(to);
     };
+
+    if (checkingLogin) {
+        return <View style={styles.app}/>;
+    }
+
+    if (!user) {
+        return <LoginPage onLogin={setUser}/>;
+    }
 
     return (
         <View style={styles.app}>

--- a/frontend/LoginPage.js
+++ b/frontend/LoginPage.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, Switch } from 'react-native';
+
+export default function LoginPage({ onLogin }) {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+
+  const handleLogin = async () => {
+    const res = await fetch('http://localhost:3000/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, password })
+    });
+    if (res.ok) {
+      const user = await res.json();
+      if (remember && typeof localStorage !== 'undefined') {
+        localStorage.setItem('login', JSON.stringify({ name, password }));
+      } else if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem('login');
+      }
+      onLogin(user);
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      <TextInput
+        placeholder="Username"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <View style={styles.rememberRow}>
+        <Switch value={remember} onValueChange={setRemember} />
+        <Text style={styles.rememberLabel}>Remember me</Text>
+      </View>
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginBottom: 8,
+    padding: 8,
+    borderRadius: 4,
+  },
+  rememberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  rememberLabel: { marginLeft: 8 },
+});


### PR DESCRIPTION
## Summary
- add password and score fields to default user data
- implement login and user creation endpoints
- migrate existing users to include password and totalScore
- add login UI with optional saved credentials
- show user points using `totalScore`
- document new login feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b889175c832f8fb1bbff7e7f0bfe