### PR TITLE
Add reusable Tile component

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,6 +1,8 @@
 import React, {useState, useEffect} from 'react';
 import {View, Text, FlatList, StyleSheet, TextInput, Button} from 'react-native';
-import {Card, IconButton} from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
+import Tile from './Tile';
+import { TASK_COLOR, USER_COLOR } from './colors';
 import NavigationBar from './NavigationBar';
 import CalendarPage from './CalendarPage';
 import TaskForm from './TaskForm';
@@ -58,19 +60,21 @@ function TaskList({navigate}) {
 }
 
 function TaskRow({item, users, onEdit, onDuplicate, onDelete, navigate}) {
+    const actions = (
+        <>
+            <IconButton icon="pencil" onPress={() => onEdit(item)} />
+            <IconButton icon="content-copy" onPress={() => onDuplicate(item.id)} />
+            <IconButton icon="calendar" onPress={() => navigate('events', item)} />
+            <IconButton icon="delete" onPress={() => onDelete(item.id)} />
+        </>
+    );
     return (
-        <Card style={styles.card}>
-            <Card.Title
-                title={item.name}
-                subtitle={`${users[item.assignedTo] || item.assignedTo} • due ${item.dueDate} • ${item.points} pts`}
-            />
-            <Card.Actions>
-                <IconButton icon="pencil" onPress={() => onEdit(item)} />
-                <IconButton icon="content-copy" onPress={() => onDuplicate(item.id)} />
-                <IconButton icon="calendar" onPress={() => navigate('events', item)} />
-                <IconButton icon="delete" onPress={() => onDelete(item.id)} />
-            </Card.Actions>
-        </Card>
+        <Tile
+            title={item.name}
+            subtitle={`${users[item.assignedTo] || item.assignedTo} • due ${item.dueDate} • ${item.points} pts`}
+            actions={actions}
+            color={TASK_COLOR}
+        />
     );
 }
 
@@ -100,7 +104,11 @@ function UsersPage({navigate}) {
                 data={users}
                 keyExtractor={(u) => u.id}
                 renderItem={({item}) => (
-                    <Text>{item.name} - {item.totalScore} pts - {item.completedTasks} tasks</Text>
+                    <Tile
+                        title={item.name}
+                        subtitle={`${item.totalScore} pts - ${item.completedTasks} tasks`}
+                        color={USER_COLOR}
+                    />
                 )}
             />
             <TextInput
@@ -181,5 +189,4 @@ const styles = StyleSheet.create({
         padding: 8,
         borderRadius: 4,
     },
-    card: {marginBottom: 8},
 });

--- a/frontend/EventsPage.js
+++ b/frontend/EventsPage.js
@@ -1,8 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import {View, Text, FlatList, StyleSheet, TextInput, Button} from 'react-native';
-import {Card, IconButton} from 'react-native-paper';
+import { IconButton } from 'react-native-paper';
 import {DatePickerInput} from 'react-native-paper-dates';
 import {LOCALE} from './config';
+import Tile from './Tile';
+import { EVENT_COLOR } from './colors';
 
 export default function EventsPage({task, navigate}) {
     const [events, setEvents] = useState([]);
@@ -51,11 +53,23 @@ function EventRow({item, onSave}) {
         setEditMode(false);
     };
 
+    const actions = editMode ? (
+        <>
+            <Button title="Save" onPress={save} />
+            <Button title="Cancel" onPress={() => setEditMode(false)} />
+        </>
+    ) : (
+        <IconButton icon="pencil" onPress={() => setEditMode(true)} />
+    );
+
     return (
-        <Card style={styles.card}>
-            <Card.Title title={`${item.date} ${item.time}`} />
+        <Tile
+            title={`${item.date} ${item.time}`}
+            color={EVENT_COLOR}
+            actions={actions}
+        >
             {editMode && (
-                <Card.Content>
+                <>
                     <DatePickerInput
                         locale={LOCALE}
                         label="Date"
@@ -70,26 +84,15 @@ function EventRow({item, onSave}) {
                         style={styles.input}
                         placeholder="HH:MM"
                     />
-                </Card.Content>
+                </>
             )}
-            <Card.Actions>
-                {editMode ? (
-                    <>
-                        <Button title="Save" onPress={save} />
-                        <Button title="Cancel" onPress={() => setEditMode(false)} />
-                    </>
-                ) : (
-                    <IconButton icon="pencil" onPress={() => setEditMode(true)} />
-                )}
-            </Card.Actions>
-        </Card>
+        </Tile>
     );
 }
 
 const styles = StyleSheet.create({
     container: {flex: 1, padding: 20},
     title: {fontSize: 24, marginBottom: 16},
-    card: {marginBottom: 8},
     input: {
         borderWidth: 1,
         borderColor: '#ccc',

--- a/frontend/Tile.js
+++ b/frontend/Tile.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Card } from 'react-native-paper';
+import { StyleSheet } from 'react-native';
+
+export default function Tile({ title, subtitle, children, actions, color }) {
+  return (
+    <Card style={[styles.card, { backgroundColor: color }]}>
+      {(title || subtitle) && <Card.Title title={title} subtitle={subtitle} />}
+      {children && <Card.Content>{children}</Card.Content>}
+      {actions && <Card.Actions>{actions}</Card.Actions>}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { marginBottom: 8 },
+});
+

--- a/frontend/colors.js
+++ b/frontend/colors.js
@@ -1,0 +1,4 @@
+export const TASK_COLOR = '#e3f2fd';
+export const EVENT_COLOR = '#e8f5e9';
+export const USER_COLOR = '#fce4ec';
+


### PR DESCRIPTION
## Summary
- introduce `Tile` component and color palette
- use `Tile` for `TaskRow`, `UsersPage` items and `EventRow`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873bb109344832f85cdfe05fab7af7d