### PR TITLE
Implement dynamic user scores and enhanced event editing

### DIFF
--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,4 +1,4 @@
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 
 module.exports = async function migrate(db) {
   await db.read();
@@ -51,6 +51,18 @@ module.exports = async function migrate(db) {
       }
     });
     db.data.migrationVersion = 3;
+    await db.write();
+  }
+
+  if (db.data.migrationVersion < 4) {
+    db.data.events = db.data.events || [];
+    db.data.events.forEach(ev => {
+      if (ev.points === undefined) {
+        const task = (db.data.tasks || []).find(t => t.id === ev.taskId);
+        ev.points = task?.points || 0;
+      }
+    });
+    db.data.migrationVersion = 4;
     await db.write();
   }
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -56,7 +56,8 @@ const app = express();
                     date: current.toISOString().split('T')[0],
                     time,
                     assignedTo: task.assignedTo,
-                    state: 'created'
+                    state: 'created',
+                    points: task.points || 0
                 });
                 if (task.repetition === 'weekly') {
                     current.setDate(current.getDate() + 7);


### PR DESCRIPTION
## Summary
- allow editing the assigned user and state on events
- show event points (read only) in the edit form
- generate events with points and migrate existing ones
- compute user statistics dynamically from completed events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e614a5c4832f87cd87b045b8d100