### PR TITLE
Add logout menu to navigation bar

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -154,6 +154,14 @@ export default function App() {
         setPage(to);
     };
 
+    const handleLogout = () => {
+        if (typeof localStorage !== 'undefined') {
+            localStorage.removeItem('login');
+        }
+        setUser(null);
+        setNavOpen(false);
+    };
+
     if (checkingLogin) {
         return <View style={styles.app}/>;
     }
@@ -164,7 +172,12 @@ export default function App() {
 
     return (
         <View style={styles.app}>
-            <NavigationBar navigate={navigate} open={navOpen} setOpen={setNavOpen} />
+            <NavigationBar
+                navigate={navigate}
+                open={navOpen}
+                setOpen={setNavOpen}
+                onLogout={handleLogout}
+            />
             {page === 'create' ? (
                 <TaskForm navigate={navigate} />
             ) : page === 'edit' ? (

--- a/frontend/NavigationBar.js
+++ b/frontend/NavigationBar.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Drawer, IconButton, Tooltip } from 'react-native-paper';
+import { Drawer, IconButton, Tooltip, Menu } from 'react-native-paper';
 
-export default function NavigationBar({ navigate, open, setOpen }) {
+export default function NavigationBar({ navigate, open, setOpen, onLogout }) {
     const items = [
         {key: 'create', label: 'Add Task', icon: 'plus'},
         {key: 'list', label: 'Task List', icon: 'format-list-bulleted'},
@@ -10,8 +10,10 @@ export default function NavigationBar({ navigate, open, setOpen }) {
         {key: 'calendar', label: 'Calendar', icon: 'calendar'},
     ];
 
+    const [menuOpen, setMenuOpen] = React.useState(false);
+
     return (
-        <View style={[styles.nav, {width: open ? 160 : 72}]}> 
+        <View style={[styles.nav, {width: open ? 200 : 80}]}>
             <IconButton
                 icon={open ? 'chevron-left' : 'chevron-right'}
                 onPress={() => setOpen(!open)}
@@ -36,6 +38,21 @@ export default function NavigationBar({ navigate, open, setOpen }) {
                     )
                 ))}
             </Drawer.Section>
+            <View style={styles.userMenu}>
+                <Menu
+                    visible={menuOpen}
+                    onDismiss={() => setMenuOpen(false)}
+                    anchor={
+                        <IconButton
+                            icon="account-circle"
+                            size={open ? 32 : 24}
+                            onPress={() => setMenuOpen(true)}
+                        />
+                    }
+                >
+                    <Menu.Item leadingIcon="logout" onPress={onLogout} title="Log Out" />
+                </Menu>
+            </View>
         </View>
     );
 }
@@ -47,5 +64,9 @@ const styles = StyleSheet.create({
     },
     toggle: {
         alignSelf: 'flex-end',
+    },
+    userMenu: {
+        alignItems: 'center',
+        marginBottom: 8,
     },
 });


### PR DESCRIPTION
## Summary
- expand navigation bar width for better label visibility
- add dropdown menu triggered by user icon with Log Out option
- wire logout to remove saved credentials and return to login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e8259108832f8cc98f418470dfe6