### PR TITLE
Add event editing shortcut on dashboard

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -190,7 +190,7 @@ export default function App() {
                 onLogout={handleLogout}
             />
             {page === 'dashboard' ? (
-                <DashboardPage user={user} />
+                <DashboardPage user={user} navigate={navigate} />
             ) : page === 'create' ? (
                 <TaskForm navigate={navigate} />
             ) : page === 'edit' ? (

--- a/frontend/DashboardPage.js
+++ b/frontend/DashboardPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { IconButton } from 'react-native-paper';
 import Tile from './Tile';
 import { EVENT_COLOR } from './colors';
 
@@ -7,7 +8,7 @@ import { EVENT_COLOR } from './colors';
  * Simple dashboard shown on login. It lists upcoming events for the
  * current user and displays the accumulated score and completed tasks.
  */
-export default function DashboardPage({ user }) {
+export default function DashboardPage({ user, navigate }) {
   const [events, setEvents] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [stats, setStats] = useState({ totalScore: 0, completedTasks: 0 });
@@ -55,6 +56,12 @@ export default function DashboardPage({ user }) {
       title={`${item.date} ${item.time || ''}`}
       subtitle={taskMap[item.taskId] || item.taskId}
       color={EVENT_COLOR}
+      actions={
+        <IconButton
+          icon="pencil"
+          onPress={() => navigate('event-edit', { event: item, origin: 'dashboard' })}
+        />
+      }
     />
   );
 


### PR DESCRIPTION
## Summary
- allow dashboard to open `EventForm` to edit events via pencil icon
- wire DashboardPage to the central `navigate` function so users return to the dashboard after editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873f7d536fc832fb3dc07767d411418