### PR TITLE
Improve date display in frontend

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -3,6 +3,7 @@ import {View, Text, FlatList, StyleSheet, TextInput, Button} from 'react-native'
 import { IconButton } from 'react-native-paper';
 import Tile from './components/Tile';
 import { TASK_COLOR, USER_COLOR } from './utils/colors';
+import { formatDateLocal } from './utils/config';
 import NavigationBar from './components/NavigationBar';
 import CalendarPage from './pages/CalendarPage';
 import TaskForm from './forms/TaskForm';
@@ -74,7 +75,7 @@ function TaskRow({item, users, onEdit, onDuplicate, onDelete, navigate}) {
     return (
         <Tile
             title={item.name}
-            subtitle={`${users[item.assignedTo] || item.assignedTo} • due ${item.dueDate} • ${item.points} pts`}
+            subtitle={`${users[item.assignedTo] || item.assignedTo} • due ${formatDateLocal(item.dueDate)} • ${item.points} pts`}
             actions={actions}
             color={TASK_COLOR}
         />

--- a/frontend/forms/TaskForm.js
+++ b/frontend/forms/TaskForm.js
@@ -14,12 +14,16 @@ export default function TaskForm({ task, navigate }) {
   const [name, setName] = useState(task?.name || '');
   const [assignedTo, setAssignedTo] = useState(task?.assignedTo || '');
   const [users, setUsers] = useState([]);
-  const [dueDate, setDueDate] = useState(task?.dueDate || formatDate(new Date()));
+  const [dueDate, setDueDate] = useState(
+    task?.dueDate ? formatDate(new Date(task.dueDate)) : formatDate(new Date())
+  );
   const [dueTime, setDueTime] = useState(formatTime(new Date()));
   const [timeVisible, setTimeVisible] = useState(false);
   const [points, setPoints] = useState(task?.points ? String(task.points) : '');
   const [repetition, setRepetition] = useState(task?.repetition || 'none');
-  const [endDate, setEndDate] = useState(task?.endDate || '');
+  const [endDate, setEndDate] = useState(
+    task?.endDate ? formatDate(new Date(task.endDate)) : ''
+  );
   const [steps, setSteps] = useState([]);
   const [newStep, setNewStep] = useState('');
 

--- a/frontend/pages/DashboardPage.js
+++ b/frontend/pages/DashboardPage.js
@@ -3,6 +3,7 @@ import { View, Text, FlatList, StyleSheet } from 'react-native';
 import { IconButton } from 'react-native-paper';
 import Tile from '../components/Tile';
 import { EVENT_COLOR } from '../utils/colors';
+import { formatDateLocal } from '../utils/config';
 
 /**
  * Simple dashboard shown on login. It lists upcoming events for the
@@ -54,7 +55,7 @@ export default function DashboardPage({ user, navigate }) {
 
   const renderItem = ({ item }) => (
     <Tile
-      title={`${item.date} ${item.time || ''}`}
+      title={`${formatDateLocal(item.date)} ${item.time || ''}`}
       subtitle={taskMap[item.taskId] || item.taskId}
       color={EVENT_COLOR}
       actions={

--- a/frontend/pages/EventsPage.js
+++ b/frontend/pages/EventsPage.js
@@ -3,6 +3,7 @@ import {View, Text, FlatList, StyleSheet, Button} from 'react-native';
 import { IconButton } from 'react-native-paper';
 import Tile from '../components/Tile';
 import { EVENT_COLOR } from '../utils/colors';
+import { formatDateLocal } from '../utils/config';
 
 export default function EventsPage({task, navigate}) {
     const [events, setEvents] = useState([]);
@@ -52,7 +53,7 @@ function EventRow({item, onComplete, navigate}) {
 
     return (
         <Tile
-            title={`${item.date} ${item.time}${item.state === 'completed' ? ' (completed)' : ''}`}
+            title={`${formatDateLocal(item.date)} ${item.time}${item.state === 'completed' ? ' (completed)' : ''}`}
             color={EVENT_COLOR}
             actions={actions}
         />

--- a/frontend/utils/config.js
+++ b/frontend/utils/config.js
@@ -1,1 +1,11 @@
 export const LOCALE = 'de-AT';
+
+/**
+ * Convert an ISO date string (YYYY-MM-DD) to a locale formatted
+ * string using the configured LOCALE constant.
+ */
+export function formatDateLocal(isoDate) {
+  if (!isoDate) return '';
+  return new Date(isoDate).toLocaleDateString(LOCALE);
+}
+


### PR DESCRIPTION
## Summary
- show dates using locale format across the app
- initialise form values with locale formatted dates
- add helper for formatting dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68754529c4a8832fa81c95016625e290