### PR TITLE
Add colored left border for tiles

### DIFF
--- a/frontend/components/Tile.js
+++ b/frontend/components/Tile.js
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native';
 
 export default function Tile({ title, subtitle, children, actions, color }) {
   return (
-    <Card style={[styles.card, { borderColor: color }]}>
+    <Card style={[styles.card, { borderLeftColor: color }]}>
       {(title || subtitle) && <Card.Title title={title} subtitle={subtitle} />}
       {children && <Card.Content>{children}</Card.Content>}
       {actions && <Card.Actions>{actions}</Card.Actions>}
@@ -17,6 +17,8 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     backgroundColor: '#fff',
     borderWidth: 1,
+    borderColor: '#ddd',
+    borderLeftWidth: 6,
   },
 });
 

--- a/frontend/utils/colors.js
+++ b/frontend/utils/colors.js
@@ -1,4 +1,4 @@
-export const TASK_COLOR = '#ddd';
-export const EVENT_COLOR = '#ddd';
-export const USER_COLOR = '#ddd';
+export const TASK_COLOR = '#e3f2fd';
+export const EVENT_COLOR = '#e8f5e9';
+export const USER_COLOR = '#fce4ec';
 


### PR DESCRIPTION
## Summary
- color-code Task, Event and User tiles
- make the colored stripe on the left of each Tile component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687554a3408c832fbe0e000e7cb03c9a