### PR TITLE
Show steps inside event tiles

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -135,6 +135,7 @@ export default function App() {
     const [user, setUser] = useState(null);
     const [globalConfig, setGlobalConfig] = useState({ workingHoursStart: '06:00', workingHoursEnd: '22:00' });
     const [checkingLogin, setCheckingLogin] = useState(true);
+    const [navigationGuard, setNavigationGuard] = useState(null);
 
     useEffect(() => {
         const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('login') : null;
@@ -159,6 +160,7 @@ export default function App() {
     }, [user]);
 
     const navigate = (to, param) => {
+        if (navigationGuard && !navigationGuard()) return;
         if (to === 'edit') setEditingTask(param);
         if (to === 'events') setEventsTask(param);
         if (to === 'event-edit') { setEditingEvent(param.event); setEventOrigin(param.origin); }
@@ -208,7 +210,7 @@ export default function App() {
             ) : page === 'settings' ? (
                 <SettingsPage user={user} setUser={setUser} navigate={navigate} />
             ) : page === 'events' ? (
-                <EventsPage task={eventsTask} navigate={navigate}/>
+                <EventsPage task={eventsTask} navigate={navigate} setNavigationGuard={setNavigationGuard}/>
             ) : page === 'event-edit' ? (
                 <EventForm event={editingEvent} navigateBack={() => navigate(eventOrigin, eventsTask)} />
             ) : (

--- a/frontend/components/Tile.js
+++ b/frontend/components/Tile.js
@@ -2,9 +2,20 @@ import React from 'react';
 import { Card } from 'react-native-paper';
 import { StyleSheet } from 'react-native';
 
-export default function Tile({ title, subtitle, children, actions, color }) {
+export default function Tile({
+  title,
+  subtitle,
+  children,
+  actions,
+  color,
+  onPress,
+  style,
+}) {
   return (
-    <Card style={[styles.card, { borderLeftColor: color }]}>
+    <Card
+      style={[styles.card, { borderLeftColor: color }, style]}
+      onPress={onPress}
+    >
       {(title || subtitle) && <Card.Title title={title} subtitle={subtitle} />}
       {children && <Card.Content>{children}</Card.Content>}
       {actions && <Card.Actions>{actions}</Card.Actions>}


### PR DESCRIPTION
## Summary
- allow Tile component to handle presses
- warn the user when leaving Events page with unfinished step progress
- fetch task steps for each event and allow ticking them off
- auto-complete an event once all steps are checked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68780673d988832f8c3a07970f177fcf