### PR TITLE
Add event filtering and deletion

### DIFF
--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -53,4 +53,14 @@ module.exports = (app, db) => {
         await db.write();
         res.json(ev);
     });
+
+    app.delete('/events/:id', async (req, res) => {
+        const { id } = req.params;
+        await db.read();
+        const idx = db.data.events.findIndex(e => e.id === id);
+        if (idx === -1) return res.status(404).json({ error: 'event not found' });
+        db.data.events.splice(idx, 1);
+        await db.write();
+        res.json({ success: true });
+    });
 };


### PR DESCRIPTION
## Summary
- allow deleting events on backend and frontend
- add tabs on Events page to filter completed vs. not completed events

## Testing
- `apt-get update`
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d27d9da88832f9fe062d6cddf6c11