### PR TITLE
Fix event time display in frontend

### DIFF
--- a/frontend/pages/DashboardPage.js
+++ b/frontend/pages/DashboardPage.js
@@ -4,7 +4,7 @@ import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
 import Tile from '../components/Tile';
 import { EVENT_COLOR } from '../utils/colors';
-import { formatDateLocal } from '../utils/config';
+import { formatDateLocal, formatTimeLocal } from '../utils/config';
 
 /**
  * Simple dashboard shown on login. It lists upcoming events for the
@@ -88,7 +88,7 @@ export default function DashboardPage({ user, navigate, setUser }) {
     const fav = (user.favorites || []).includes(item.id);
     return (
       <Tile
-        title={`${formatDateLocal(item.date)} ${item.time || ''}`}
+        title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.time)}`}
         subtitle={taskMap[item.taskId] || item.taskId}
         color={EVENT_COLOR}
         actions={

--- a/frontend/pages/EventsPage.js
+++ b/frontend/pages/EventsPage.js
@@ -4,7 +4,7 @@ import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
 import Tile from '../components/Tile';
 import { EVENT_COLOR } from '../utils/colors';
-import { formatDateLocal } from '../utils/config';
+import { formatDateLocal, formatTimeLocal } from '../utils/config';
 
 export default function EventsPage({ task, navigate, setNavigationGuard, user, setUser }) {
     const [events, setEvents] = useState([]);
@@ -173,7 +173,7 @@ function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, 
 
     return (
         <Tile
-            title={`${formatDateLocal(item.date)} ${item.time}${item.state === 'completed' ? ' (completed)' : ''}`}
+            title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.time)}${item.state === 'completed' ? ' (completed)' : ''}`}
             color={EVENT_COLOR}
             actions={actions}
             onPress={() => setExpanded(!expanded)}

--- a/frontend/utils/config.js
+++ b/frontend/utils/config.js
@@ -9,3 +9,24 @@ export function formatDateLocal(isoDate) {
   return new Date(isoDate).toLocaleDateString(LOCALE);
 }
 
+/**
+ * Convert a time string into a locale formatted string.
+ * The input may either be a bare "HH:MM" value or an ISO timestamp.
+ */
+export function formatTimeLocal(timeStr) {
+  if (!timeStr) return '';
+  let date;
+  if (/^\d{4}-\d{2}-\d{2}T/.test(timeStr)) {
+    // Full ISO timestamp
+    date = new Date(timeStr);
+  } else {
+    const [h, m] = timeStr.split(':');
+    date = new Date();
+    date.setHours(parseInt(h, 10));
+    date.setMinutes(parseInt(m, 10));
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+  }
+  return date.toLocaleTimeString(LOCALE, { hour: '2-digit', minute: '2-digit' });
+}
+


### PR DESCRIPTION
## Summary
- add `formatTimeLocal` helper in config
- use `formatTimeLocal` when showing event times

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d2bb478e0832fb57cda0271459ff4