### PR TITLE
Unify event date and time

### DIFF
--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -1,4 +1,4 @@
-const { normalizeDate } = require('./utils');
+const { normalizeDateTime } = require('./utils');
 const { v4: uuidv4 } = require('uuid');
 
 module.exports = (app, db) => {
@@ -18,11 +18,16 @@ module.exports = (app, db) => {
         if (!task) return res.status(404).json({ error: 'task not found' });
 
         const now = new Date();
+        let dateTime;
+        try {
+            dateTime = normalizeDateTime(date || now.toISOString(), time);
+        } catch (err) {
+            return res.status(400).json({ error: err.message });
+        }
         const ev = {
             id: uuidv4(),
             taskId,
-            date: normalizeDate(date || now.toISOString().split('T')[0]),
-            time: time || now.toISOString().split('T')[1].slice(0,5),
+            date: dateTime,
             assignedTo: assignedTo || task.assignedTo,
             state: 'created',
             points: points !== undefined ? points : (task.points || 0)
@@ -40,14 +45,14 @@ module.exports = (app, db) => {
 
         const { taskId, date, time, state, assignedTo } = req.body;
         if (taskId !== undefined) ev.taskId = taskId;
-        if (date !== undefined) {
+        if (date !== undefined || time !== undefined) {
             try {
-                ev.date = normalizeDate(date);
+                const dt = normalizeDateTime(date || ev.date, time || ev.date.split('T')[1]);
+                ev.date = dt;
             } catch (err) {
                 return res.status(400).json({ error: err.message });
             }
         }
-        if (time !== undefined) ev.time = time;
         if (assignedTo !== undefined) ev.assignedTo = assignedTo;
         if (state !== undefined) ev.state = state;
         await db.write();

--- a/backend/routes/utils.js
+++ b/backend/routes/utils.js
@@ -14,6 +14,20 @@ function normalizeDate(input) {
     return format(date, 'yyyy-MM-dd');
 }
 
+function normalizeDateTime(dateInput, timeInput) {
+    if (!dateInput && !timeInput) return null;
+    if (dateInput && dateInput.includes('T') && !timeInput) {
+        const date = new Date(dateInput);
+        if (isNaN(date)) throw new Error(`Ungültiges Datum/Zeit: ${dateInput}`);
+        return format(date, "yyyy-MM-dd'T'HH:mm");
+    }
+    const datePart = normalizeDate(dateInput || new Date());
+    const timePart = (timeInput || '00:00').slice(0,5);
+    const dt = new Date(`${datePart}T${timePart}`);
+    if (isNaN(dt)) throw new Error(`Ungültiges Datum/Zeit: ${dateInput} ${timeInput}`);
+    return format(dt, "yyyy-MM-dd'T'HH:mm");
+}
+
 function generateEvents(task) {
     const events = [];
     let current = new Date(task.dueDate);
@@ -23,8 +37,7 @@ function generateEvents(task) {
         events.push({
             id: uuidv4(),
             taskId: task.id,
-            date: current.toISOString().split('T')[0],
-            time,
+            date: `${current.toISOString().split('T')[0]}T${time}`,
             assignedTo: task.assignedTo,
             state: 'created',
             points: task.points || 0
@@ -52,4 +65,4 @@ function applyTaskData(task, data) {
     if (endDate !== undefined) task.endDate = normalizeDate(endDate);
 }
 
-module.exports = { normalizeDate, generateEvents, applyTaskData };
+module.exports = { normalizeDate, normalizeDateTime, generateEvents, applyTaskData };

--- a/backend/scripts/migrate.js
+++ b/backend/scripts/migrate.js
@@ -1,4 +1,4 @@
-const CURRENT_VERSION = 6;
+const CURRENT_VERSION = 7;
 
 module.exports = async function migrate(db) {
   await db.read();
@@ -92,6 +92,20 @@ module.exports = async function migrate(db) {
       u.favorites = u.favorites.filter(id => valid.has(id));
     });
     db.data.migrationVersion = 6;
+    await db.write();
+  }
+
+  if (db.data.migrationVersion < 7) {
+    db.data.events = db.data.events || [];
+    db.data.events.forEach(ev => {
+      if (!ev.date) return;
+      if (!ev.date.includes('T')) {
+        const time = ev.time || '00:00';
+        ev.date = `${ev.date}T${time}`;
+      }
+      delete ev.time;
+    });
+    db.data.migrationVersion = 7;
     await db.write();
   }
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,7 +24,7 @@ const app = express();
         }
     };
     const defaultData = {
-        migrationVersion: 6,
+        migrationVersion: 7,
         users: [defaultUser],
         tasks: [
             {
@@ -62,8 +62,7 @@ const app = express();
                 events.push({
                     id: uuidv4(),
                     taskId: task.id,
-                    date: current.toISOString().split('T')[0],
-                    time,
+                    date: `${current.toISOString().split('T')[0]}T${time}`,
                     assignedTo: task.assignedTo,
                     state: 'created',
                     points: task.points || 0
@@ -90,10 +89,12 @@ const app = express();
     async function reschedulePastEvents() {
         await db.read();
         const today = new Date().toISOString().split('T')[0];
+        const startToday = new Date(`${today}T00:00`);
         db.data.events.sort((a, b) => new Date(a.date) - new Date(b.date));
         db.data.events.forEach(ev => {
-            if (new Date(ev.date) < new Date(today) && ev.state !== 'completed') {
-                ev.date = today;
+            if (new Date(ev.date) < startToday && ev.state !== 'completed') {
+                const timePart = ev.date.includes('T') ? ev.date.split('T')[1] : '00:00';
+                ev.date = `${today}T${timePart}`;
                 ev.state = 'delayed';
             }
         });

--- a/frontend/forms/EventForm.js
+++ b/frontend/forms/EventForm.js
@@ -12,8 +12,8 @@ import { LOCALE } from '../utils/config';
  * user returns after submitting the changes.
  */
 export default function EventForm({ event, navigateBack }) {
-  const [date, setDate] = useState(event.date);
-  const [time, setTime] = useState(event.time || '');
+  const [date, setDate] = useState(event.date.split('T')[0]);
+  const [time, setTime] = useState(event.date.split('T')[1]?.slice(0,5) || '');
   const [assignedTo, setAssignedTo] = useState(event.assignedTo || '');
   const [state, setState] = useState(event.state || 'created');
   const [users, setUsers] = useState([]);
@@ -29,10 +29,11 @@ export default function EventForm({ event, navigateBack }) {
   }, []);
 
   const saveEvent = async () => {
+    const iso = `${date}T${time}`;
     await fetch(`http://localhost:3000/events/${event.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ date, time, assignedTo, state }),
+      body: JSON.stringify({ date: iso, assignedTo, state }),
     });
   };
 

--- a/frontend/pages/CalendarPage.js
+++ b/frontend/pages/CalendarPage.js
@@ -33,8 +33,9 @@ export default function CalendarPage({ navigate, user, globalConfig }) {
     const itemsByDate = useMemo(() => {
         return events.reduce((acc, ev) => {
             if (!ev.date) return acc;
-            acc[ev.date] = acc[ev.date] || [];
-            acc[ev.date].push(ev);
+            const key = ev.date.split('T')[0];
+            acc[key] = acc[key] || [];
+            acc[key].push(ev);
             return acc;
         }, {});
     }, [events]);
@@ -69,7 +70,7 @@ export default function CalendarPage({ navigate, user, globalConfig }) {
         if (!selectedDate) return [];
         const isoDate = convertToISO(selectedDate);
         return (itemsByDate[isoDate] || []).map(ev => {
-            const start = new Date(`${ev.date}T${ev.time || '00:00'}`);
+            const start = new Date(ev.date);
             const end = new Date(start.getTime() + 60 * 60 * 1000);
             return {
                 id: ev.id,

--- a/frontend/pages/DashboardPage.js
+++ b/frontend/pages/DashboardPage.js
@@ -49,25 +49,13 @@ export default function DashboardPage({ user, navigate, setUser }) {
   const sorted = useMemo(() => {
     const upcoming = events
       .filter(e => e.state !== 'completed')
-      .sort((a, b) => {
-        const da = new Date(`${a.date}T${a.time || '00:00'}`);
-        const db = new Date(`${b.date}T${b.time || '00:00'}`);
-        return da - db;
-      });
+      .sort((a, b) => new Date(a.date) - new Date(b.date));
     const completed = events
       .filter(e => e.state === 'completed')
-      .sort((a, b) => {
-        const da = new Date(`${a.date}T${a.time || '00:00'}`);
-        const db = new Date(`${b.date}T${b.time || '00:00'}`);
-        return db - da;
-      });
+      .sort((a, b) => new Date(b.date) - new Date(a.date));
     const favorites = events
       .filter(e => (user.favorites || []).includes(e.id))
-      .sort((a, b) => {
-        const da = new Date(`${a.date}T${a.time || '00:00'}`);
-        const db = new Date(`${b.date}T${b.time || '00:00'}`);
-        return da - db;
-      });
+      .sort((a, b) => new Date(a.date) - new Date(b.date));
     return { upcoming, completed, favorites };
   }, [events, user.favorites]);
 
@@ -88,7 +76,7 @@ export default function DashboardPage({ user, navigate, setUser }) {
     const fav = (user.favorites || []).includes(item.id);
     return (
       <Tile
-        title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.time)}`}
+        title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.date)}`}
         subtitle={taskMap[item.taskId] || item.taskId}
         color={EVENT_COLOR}
         actions={

--- a/frontend/pages/EventsPage.js
+++ b/frontend/pages/EventsPage.js
@@ -14,11 +14,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
     const load = async () => {
         const res = await fetch(`http://localhost:3000/events?taskId=${task.id}`);
         const data = await res.json();
-        data.sort((a, b) => {
-            const da = new Date(`${a.date}T${a.time || '00:00'}`);
-            const db = new Date(`${b.date}T${b.time || '00:00'}`);
-            return da - db;
-        });
+        data.sort((a, b) => new Date(a.date) - new Date(b.date));
         setEvents(data);
     };
 
@@ -173,7 +169,7 @@ function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, 
 
     return (
         <Tile
-            title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.time)}${item.state === 'completed' ? ' (completed)' : ''}`}
+            title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.date)}${item.state === 'completed' ? ' (completed)' : ''}`}
             color={EVENT_COLOR}
             actions={actions}
             onPress={() => setExpanded(!expanded)}

--- a/frontend/utils/config.js
+++ b/frontend/utils/config.js
@@ -1,7 +1,7 @@
 export const LOCALE = 'de-AT';
 
 /**
- * Convert an ISO date string (YYYY-MM-DD) to a locale formatted
+ * Convert an ISO date string to a locale formatted
  * string using the configured LOCALE constant.
  */
 export function formatDateLocal(isoDate) {


### PR DESCRIPTION
## Summary
- migrate existing events to single `date` field including time
- adjust backend for new ISO datetime
- rewrite event generation and rescheduling logic
- update frontend pages and forms for datetime field
- handle locale formatting for new ISO strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d354cb440832fa35b44c9ed4eb2f7