### PR TITLE
Fix time zones

### DIFF
--- a/backend/routes/utils.js
+++ b/backend/routes/utils.js
@@ -19,13 +19,13 @@ function normalizeDateTime(dateInput, timeInput) {
     if (dateInput && dateInput.includes('T') && !timeInput) {
         const date = new Date(dateInput);
         if (isNaN(date)) throw new Error(`Ungültiges Datum/Zeit: ${dateInput}`);
-        return format(date, "yyyy-MM-dd'T'HH:mm");
+        return date.toISOString();
     }
     const datePart = normalizeDate(dateInput || new Date());
-    const timePart = (timeInput || '00:00').slice(0,5);
-    const dt = new Date(`${datePart}T${timePart}`);
-    if (isNaN(dt)) throw new Error(`Ungültiges Datum/Zeit: ${dateInput} ${timeInput}`);
-    return format(dt, "yyyy-MM-dd'T'HH:mm");
+    const timePart = (timeInput || '00:00').slice(0, 5);
+    const dtLocal = new Date(`${datePart}T${timePart}`);
+    if (isNaN(dtLocal)) throw new Error(`Ungültiges Datum/Zeit: ${dateInput} ${timeInput}`);
+    return dtLocal.toISOString();
 }
 
 function generateEvents(task) {
@@ -37,7 +37,7 @@ function generateEvents(task) {
         events.push({
             id: uuidv4(),
             taskId: task.id,
-            date: `${current.toISOString().split('T')[0]}T${time}`,
+            date: `${current.toISOString().split('T')[0]}T${time}Z`,
             assignedTo: task.assignedTo,
             state: 'created',
             points: task.points || 0

--- a/backend/server.js
+++ b/backend/server.js
@@ -62,7 +62,7 @@ const app = express();
                 events.push({
                     id: uuidv4(),
                     taskId: task.id,
-                    date: `${current.toISOString().split('T')[0]}T${time}`,
+                    date: `${current.toISOString().split('T')[0]}T${time}Z`,
                     assignedTo: task.assignedTo,
                     state: 'created',
                     points: task.points || 0
@@ -89,11 +89,12 @@ const app = express();
     async function reschedulePastEvents() {
         await db.read();
         const today = new Date().toISOString().split('T')[0];
-        const startToday = new Date(`${today}T00:00`);
+        const startToday = new Date(`${today}T00:00Z`);
         db.data.events.sort((a, b) => new Date(a.date) - new Date(b.date));
         db.data.events.forEach(ev => {
             if (new Date(ev.date) < startToday && ev.state !== 'completed') {
-                const timePart = ev.date.includes('T') ? ev.date.split('T')[1] : '00:00';
+                let timePart = ev.date.includes('T') ? ev.date.split('T')[1] : '00:00';
+                if (!timePart.endsWith('Z')) timePart += 'Z';
                 ev.date = `${today}T${timePart}`;
                 ev.state = 'delayed';
             }

--- a/frontend/forms/EventForm.js
+++ b/frontend/forms/EventForm.js
@@ -12,8 +12,15 @@ import { LOCALE } from '../utils/config';
  * user returns after submitting the changes.
  */
 export default function EventForm({ event, navigateBack }) {
-  const [date, setDate] = useState(event.date.split('T')[0]);
-  const [time, setTime] = useState(event.date.split('T')[1]?.slice(0,5) || '');
+  const toLocalDate = d => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+  const initial = new Date(event.date);
+  const [date, setDate] = useState(toLocalDate(initial));
+  const [time, setTime] = useState(initial.toTimeString().slice(0,5));
   const [assignedTo, setAssignedTo] = useState(event.assignedTo || '');
   const [state, setState] = useState(event.state || 'created');
   const [users, setUsers] = useState([]);
@@ -29,7 +36,7 @@ export default function EventForm({ event, navigateBack }) {
   }, []);
 
   const saveEvent = async () => {
-    const iso = `${date}T${time}`;
+    const iso = new Date(`${date}T${time}`).toISOString();
     await fetch(`http://localhost:3000/events/${event.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -57,7 +64,7 @@ export default function EventForm({ event, navigateBack }) {
         locale={LOCALE}
         label="Date"
         value={new Date(date)}
-        onChange={d => setDate(d.toISOString().split('T')[0])}
+        onChange={d => setDate(toLocalDate(d))}
         inputEnabled
         style={styles.input}
       />


### PR DESCRIPTION
## Summary
- save events in UTC on the backend and when editing events
- keep reschedule logic in UTC
- convert event form dates and times to and from local time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d381b1634832fa03331780ab6fe0d