### PR TITLE
Add button to export events to Google Calendar

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -50,13 +50,15 @@ module.exports = (app, db) => {
 
     app.patch('/users/:id/config', async (req, res) => {
         const { id } = req.params;
-        const { workingHoursStart, workingHoursEnd } = req.body;
+        const { workingHoursStart, workingHoursEnd, googleCalendarId, googleApiKey } = req.body;
         await db.read();
         const user = db.data.users.find(u => u.id === id);
         if (!user) return res.status(404).json({ error: 'user not found' });
         user.config = user.config || {};
         if (workingHoursStart !== undefined) user.config.workingHoursStart = workingHoursStart;
         if (workingHoursEnd !== undefined) user.config.workingHoursEnd = workingHoursEnd;
+        if (googleCalendarId !== undefined) user.config.googleCalendarId = googleCalendarId;
+        if (googleApiKey !== undefined) user.config.googleApiKey = googleApiKey;
         await db.write();
         const { password: pw, ...safeUser } = user;
         res.json(safeUser);

--- a/backend/scripts/migrate.js
+++ b/backend/scripts/migrate.js
@@ -1,4 +1,4 @@
-const CURRENT_VERSION = 7;
+const CURRENT_VERSION = 8;
 
 module.exports = async function migrate(db) {
   await db.read();
@@ -106,6 +106,17 @@ module.exports = async function migrate(db) {
       delete ev.time;
     });
     db.data.migrationVersion = 7;
+    await db.write();
+  }
+
+  if (db.data.migrationVersion < 8) {
+    db.data.users = db.data.users || [];
+    db.data.users.forEach(u => {
+      u.config = u.config || {};
+      if (u.config.googleCalendarId === undefined) u.config.googleCalendarId = '';
+      if (u.config.googleApiKey === undefined) u.config.googleApiKey = '';
+    });
+    db.data.migrationVersion = 8;
     await db.write();
   }
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,11 +20,13 @@ const app = express();
         favorites: [],
         config: {
             workingHoursStart: '07:00',
-            workingHoursEnd: '22:00'
+            workingHoursEnd: '22:00',
+            googleCalendarId: '',
+            googleApiKey: ''
         }
     };
     const defaultData = {
-        migrationVersion: 7,
+        migrationVersion: 8,
         users: [defaultUser],
         tasks: [
             {

--- a/frontend/components/EventTile.js
+++ b/frontend/components/EventTile.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { IconButton } from 'react-native-paper';
+import Tile from './Tile';
+import { EVENT_COLOR } from '../utils/colors';
+import { formatDateLocal, formatTimeLocal } from '../utils/config';
+
+export default function EventTile({
+  event,
+  taskName,
+  user,
+  setUser,
+  navigate,
+  onComplete,
+  onDelete,
+  onPress,
+  children,
+}) {
+  const toggleFavorite = async () => {
+    const fav = !(user.favorites || []).includes(event.id);
+    await fetch(`http://localhost:3000/users/${user.id}/favorites`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventId: event.id, favorite: fav }),
+    });
+    const list = fav
+      ? [ ...(user.favorites || []), event.id ]
+      : (user.favorites || []).filter(f => f !== event.id);
+    setUser({ ...user, favorites: list });
+  };
+
+  const addToGoogle = async () => {
+    const calId = user.config?.googleCalendarId;
+    const apiKey = user.config?.googleApiKey;
+    if (!calId || !apiKey) {
+      alert('Google Calendar credentials missing in settings');
+      return;
+    }
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const start = new Date(event.date);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const toLocal = d => d.toLocaleString('sv-SE', { timeZone: tz }).replace(' ', 'T');
+    const body = {
+      summary: taskName,
+      start: { dateTime: toLocal(start), timeZone: tz },
+      end: { dateTime: toLocal(end), timeZone: tz },
+    };
+    try {
+      const url = `https://www.googleapis.com/calendar/v3/calendars/${calId}/events?key=${apiKey}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        alert('Event added to Google Calendar');
+      } else {
+        const msg = await res.text();
+        alert('Failed to add event: ' + msg);
+      }
+    } catch (e) {
+      alert('Failed to add event');
+    }
+  };
+
+  const actions = (
+    <>
+      <IconButton
+        icon={(user.favorites || []).includes(event.id) ? 'star' : 'star-outline'}
+        onPress={toggleFavorite}
+      />
+      {onComplete && (
+        <IconButton
+          icon="check"
+          onPress={() => onComplete(event.id)}
+          disabled={event.state === 'completed'}
+        />
+      )}
+      {navigate && (
+        <IconButton
+          icon="pencil"
+          onPress={() => navigate('event-edit', { event, origin: 'events' })}
+        />
+      )}
+      <IconButton icon="google" onPress={addToGoogle} />
+      {onDelete && <IconButton icon="delete" onPress={() => onDelete(event.id)} />}
+    </>
+  );
+
+  return (
+    <Tile
+      title={`${formatDateLocal(event.date)} ${formatTimeLocal(event.date)}${event.state === 'completed' ? ' (completed)' : ''}`}
+      subtitle={taskName}
+      color={EVENT_COLOR}
+      actions={actions}
+      onPress={onPress}
+    >
+      {children}
+    </Tile>
+  );
+}

--- a/frontend/pages/DashboardPage.js
+++ b/frontend/pages/DashboardPage.js
@@ -1,10 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
-import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
-import Tile from '../components/Tile';
-import { EVENT_COLOR } from '../utils/colors';
-import { formatDateLocal, formatTimeLocal } from '../utils/config';
+import EventTile from '../components/EventTile';
+
 
 /**
  * Simple dashboard shown on login. It lists upcoming events for the
@@ -59,41 +57,16 @@ export default function DashboardPage({ user, navigate, setUser }) {
     return { upcoming, completed, favorites };
   }, [events, user.favorites]);
 
-  const toggleFavorite = async (id) => {
-    const fav = !(user.favorites || []).includes(id);
-    await fetch(`http://localhost:3000/users/${user.id}/favorites`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ eventId: id, favorite: fav })
-    });
-    const list = fav
-      ? [ ...(user.favorites || []), id ]
-      : (user.favorites || []).filter(f => f !== id);
-    setUser({ ...user, favorites: list });
-  };
 
-  const renderItem = ({ item }) => {
-    const fav = (user.favorites || []).includes(item.id);
-    return (
-      <Tile
-        title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.date)}`}
-        subtitle={taskMap[item.taskId] || item.taskId}
-        color={EVENT_COLOR}
-        actions={
-          <>
-            <IconButton
-              icon={fav ? 'star' : 'star-outline'}
-              onPress={() => toggleFavorite(item.id)}
-            />
-            <IconButton
-              icon="pencil"
-              onPress={() => navigate('event-edit', { event: item, origin: 'dashboard' })}
-            />
-          </>
-        }
-      />
-    );
-  };
+  const renderItem = ({ item }) => (
+    <EventTile
+      event={item}
+      taskName={taskMap[item.taskId] || item.taskId}
+      user={user}
+      setUser={setUser}
+      navigate={navigate}
+    />
+  );
 
   return (
     <View style={styles.container}>

--- a/frontend/pages/EventsPage.js
+++ b/frontend/pages/EventsPage.js
@@ -2,9 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet, Button } from 'react-native';
 import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
-import Tile from '../components/Tile';
-import { EVENT_COLOR } from '../utils/colors';
-import { formatDateLocal, formatTimeLocal } from '../utils/config';
+import EventTile from '../components/EventTile';
 
 export default function EventsPage({ task, navigate, setNavigationGuard, user, setUser }) {
     const [events, setEvents] = useState([]);
@@ -78,6 +76,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
             }
             user={user}
             setUser={setUser}
+            task={task}
         />
     );
 
@@ -117,7 +116,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
     );
 }
 
-function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, setUser }) {
+function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, setUser, task }) {
     const [steps, setSteps] = useState([]);
     const [done, setDone] = useState({});
     const [expanded, setExpanded] = useState(false);
@@ -145,33 +144,15 @@ function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, 
         setDone(d => ({ ...d, [id]: !d[id] }));
     };
 
-    const toggleFavorite = async () => {
-        const fav = !(user.favorites || []).includes(item.id);
-        await fetch(`http://localhost:3000/users/${user.id}/favorites`, {
-            method: 'PATCH',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ eventId: item.id, favorite: fav })
-        });
-        const list = fav
-            ? [ ...(user.favorites || []), item.id ]
-            : (user.favorites || []).filter(f => f !== item.id);
-        setUser({ ...user, favorites: list });
-    };
-
-    const actions = (
-        <>
-            <IconButton icon={(user.favorites || []).includes(item.id) ? 'star' : 'star-outline'} onPress={toggleFavorite} />
-            <IconButton icon="check" onPress={() => onComplete(item.id)} disabled={item.state === 'completed'} />
-            <IconButton icon="pencil" onPress={() => navigate('event-edit', { event: item, origin: 'events' })} />
-            <IconButton icon="delete" onPress={() => onDelete(item.id)} />
-        </>
-    );
-
     return (
-        <Tile
-            title={`${formatDateLocal(item.date)} ${formatTimeLocal(item.date)}${item.state === 'completed' ? ' (completed)' : ''}`}
-            color={EVENT_COLOR}
-            actions={actions}
+        <EventTile
+            event={item}
+            taskName={task.name}
+            user={user}
+            setUser={setUser}
+            onComplete={onComplete}
+            onDelete={onDelete}
+            navigate={navigate}
             onPress={() => setExpanded(!expanded)}
         >
             <View style={expanded ? null : styles.stepContainer}>
@@ -186,7 +167,7 @@ function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, 
                     </View>
                 ))}
             </View>
-        </Tile>
+        </EventTile>
     );
 }
 

--- a/frontend/pages/SettingsPage.js
+++ b/frontend/pages/SettingsPage.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { View, Button, StyleSheet } from 'react-native';
+import { View, Button, StyleSheet, TextInput } from 'react-native';
 import { TimePickerModal } from 'react-native-paper-dates';
 import HomeChoresFormComponent from '../components/HomeChoresFormComponent';
 
 export default function SettingsPage({ user, setUser, navigate }) {
   const [start, setStart] = useState(user.config?.workingHoursStart || '06:00');
   const [end, setEnd] = useState(user.config?.workingHoursEnd || '22:00');
+  const [calendarId, setCalendarId] = useState(user.config?.googleCalendarId || '');
+  const [apiKey, setApiKey] = useState(user.config?.googleApiKey || '');
   const [showStart, setShowStart] = useState(false);
   const [showEnd, setShowEnd] = useState(false);
 
@@ -13,9 +15,23 @@ export default function SettingsPage({ user, setUser, navigate }) {
     await fetch(`http://localhost:3000/users/${user.id}/config`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ workingHoursStart: start, workingHoursEnd: end })
+      body: JSON.stringify({
+        workingHoursStart: start,
+        workingHoursEnd: end,
+        googleCalendarId: calendarId,
+        googleApiKey: apiKey,
+      })
     });
-    setUser({ ...user, config: { ...user.config, workingHoursStart: start, workingHoursEnd: end } });
+    setUser({
+      ...user,
+      config: {
+        ...user.config,
+        workingHoursStart: start,
+        workingHoursEnd: end,
+        googleCalendarId: calendarId,
+        googleApiKey: apiKey,
+      },
+    });
     navigate('list');
   };
 
@@ -51,10 +67,29 @@ export default function SettingsPage({ user, setUser, navigate }) {
         hours={parseInt(end.split(':')[0], 10)}
         minutes={parseInt(end.split(':')[1], 10)}
       />
+      <TextInput
+        placeholder="Google Calendar ID"
+        value={calendarId}
+        onChangeText={setCalendarId}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Google API Key"
+        value={apiKey}
+        onChangeText={setApiKey}
+        style={styles.input}
+      />
     </HomeChoresFormComponent>
   );
 }
 
 const styles = StyleSheet.create({
-  row: { marginBottom: 8 }
+  row: { marginBottom: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginBottom: 8,
+    padding: 8,
+    borderRadius: 4,
+  },
 });


### PR DESCRIPTION
## Summary
- store Google Calendar credentials in user settings
- migrate existing data to include new config fields
- expose settings fields for calendar ID and API key
- add component `EventTile` to render events
- use `EventTile` in dashboard and events pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886330f0bf8832fac41b41ab7c3603a