### PR TITLE
Support Railway deployment and configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,32 @@ version, make sure the optional `deprecated-react-native-prop-types` package is
 installed. It is included in `package.json` and used as a polyfill in
 `frontend/index.js`.
 
-To run the application:
+To start the backend server:
 
 ```bash
 npm start
 ```
 
-The `npm start` command launches the React Native development server via [Expo](https://expo.dev/).  In a separate terminal you should run the backend server:
+This command launches the Express server. By default it listens on port 3000 but will respect the `PORT` environment variable when provided (as Railway does).
+
+To run the React Native frontend for development:
 
 ```bash
-node backend/server.js
+npm run dev
 ```
 
-The backend listens on `http://localhost:3000` to store tasks in a local JSON file.  You can open the Expo URL on your mobile device to interact with the app.
+The Expo server URL can be opened on your mobile device to interact with the app.
+
 When the server starts it immediately checks for events whose date lies in the past.
 Such events are moved to the current day and marked with the state `delayed`.
 This check is repeated automatically every hour while the server is running.
+
+### Deploying on Railway
+
+Railway runs `npm start` by default and supplies the `PORT` environment variable.
+Attach a persistent volume so `backend/db.json` is not lost between restarts.
+
+Set the `EXPO_PUBLIC_API_URL` environment variable in the frontend so it can reach the deployed backend.
 
 ### Loading sample tasks
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -111,7 +111,7 @@ const app = express();
     app.use(express.json());
     require('./routes')(app, db);
 
-    const port = 3000;
+    const port = process.env.PORT || 3000;
     app.listen(port, () => {
         console.log(`Server running on http://localhost:${port}`);
     });

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -12,6 +12,7 @@ import SettingsPage from './pages/SettingsPage';
 import DashboardPage from './pages/DashboardPage';
 import TaskPage from './pages/TaskPage';
 import UserPage from './pages/UserPage';
+import API_URL from './api';
 
 const theme = {
     ...MD3LightTheme,
@@ -40,7 +41,7 @@ export default function App() {
         const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('login') : null;
         if (!saved) { setCheckingLogin(false); return; }
         const {name, password} = JSON.parse(saved);
-        fetch('http://localhost:3000/login', {
+        fetch(`${API_URL}/login`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({name, password})
@@ -52,7 +53,7 @@ export default function App() {
 
     useEffect(() => {
         if (!user) return;
-        fetch('http://localhost:3000/config')
+        fetch(`${API_URL}/config`)
             .then(res => res.json())
             .then(setGlobalConfig)
             .catch(() => {});

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,0 +1,2 @@
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000';
+export default API_URL;

--- a/frontend/components/EventTile.js
+++ b/frontend/components/EventTile.js
@@ -3,6 +3,7 @@ import { IconButton } from 'react-native-paper';
 import Tile from './Tile';
 import { EVENT_COLOR } from '../utils/colors';
 import { formatDateLocal, formatTimeLocal } from '../utils/config';
+import API_URL from '../api';
 
 export default function EventTile({
   event,
@@ -17,7 +18,7 @@ export default function EventTile({
 }) {
   const toggleFavorite = async () => {
     const fav = !(user.favorites || []).includes(event.id);
-    await fetch(`http://localhost:3000/users/${user.id}/favorites`, {
+    await fetch(`${API_URL}/users/${user.id}/favorites`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ eventId: event.id, favorite: fav }),

--- a/frontend/forms/EventForm.js
+++ b/frontend/forms/EventForm.js
@@ -4,6 +4,7 @@ import { Picker } from '@react-native-picker/picker';
 import { DatePickerInput } from 'react-native-paper-dates';
 import HomeChoresFormComponent from '../components/HomeChoresFormComponent';
 import { LOCALE } from '../utils/config';
+import API_URL from '../api';
 
 /**
  * Form for editing a single event.  It reuses the generic
@@ -27,7 +28,7 @@ export default function EventForm({ event, navigateBack }) {
 
   useEffect(() => {
     const load = async () => {
-      const res = await fetch('http://localhost:3000/users');
+      const res = await fetch(`${API_URL}/users`);
       const data = await res.json();
       setUsers(data);
       if (!assignedTo && data.length > 0) setAssignedTo(data[0].id);
@@ -37,7 +38,7 @@ export default function EventForm({ event, navigateBack }) {
 
   const saveEvent = async () => {
     const iso = new Date(`${date}T${time}`).toISOString();
-    await fetch(`http://localhost:3000/events/${event.id}`, {
+    await fetch(`${API_URL}/events/${event.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ date: iso, assignedTo, state }),

--- a/frontend/forms/TaskForm.js
+++ b/frontend/forms/TaskForm.js
@@ -5,6 +5,7 @@ import { Picker } from '@react-native-picker/picker';
 import { DatePickerInput, TimePickerModal } from 'react-native-paper-dates';
 import { LOCALE } from '../utils/config';
 import HomeChoresFormComponent from '../components/HomeChoresFormComponent';
+import API_URL from '../api';
 
 export default function TaskForm({ task, navigate }) {
   const editMode = !!task;
@@ -33,14 +34,14 @@ export default function TaskForm({ task, navigate }) {
 
   useEffect(() => {
     const load = async () => {
-      const res = await fetch('http://localhost:3000/users');
+      const res = await fetch(`${API_URL}/users`);
       const data = await res.json();
       setUsers(data);
       if (!assignedTo && data.length > 0) {
         setAssignedTo(data[0].id);
       }
       if (editMode) {
-        const r2 = await fetch(`http://localhost:3000/steps?taskId=${task.id}`);
+        const r2 = await fetch(`${API_URL}/steps?taskId=${task.id}`);
         const sdata = await r2.json();
         setSteps(sdata);
       }
@@ -60,21 +61,21 @@ export default function TaskForm({ task, navigate }) {
   const saveTask = async () => {
     const data = { name, assignedTo, dueDate, dueTime, points, repetition, endDate };
     if (editMode) {
-      await fetch(`http://localhost:3000/tasks/${task.id}`, {
+      await fetch(`${API_URL}/tasks/${task.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
     } else {
       data.steps = steps.map(s => s.text);
-      const res = await fetch('http://localhost:3000/tasks', {
+      const res = await fetch(`${API_URL}/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
       const created = await res.json();
       for (const s of steps) {
-        await fetch('http://localhost:3000/steps', {
+        await fetch(`${API_URL}/steps`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ taskId: created.id, text: s.text })
@@ -91,12 +92,12 @@ export default function TaskForm({ task, navigate }) {
   const addStep = async () => {
     if (!newStep.trim()) return;
     if (editMode) {
-      await fetch('http://localhost:3000/steps', {
+      await fetch(`${API_URL}/steps`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ taskId: task.id, text: newStep })
       });
-      const r = await fetch(`http://localhost:3000/steps?taskId=${task.id}`);
+      const r = await fetch(`${API_URL}/steps?taskId=${task.id}`);
       setSteps(await r.json());
     } else {
       setSteps([...steps, { id: Date.now().toString(), text: newStep }]);
@@ -106,8 +107,8 @@ export default function TaskForm({ task, navigate }) {
 
   const removeStep = async (id) => {
     if (editMode) {
-      await fetch(`http://localhost:3000/steps/${id}`, { method: 'DELETE' });
-      const r = await fetch(`http://localhost:3000/steps?taskId=${task.id}`);
+      await fetch(`${API_URL}/steps/${id}`, { method: 'DELETE' });
+      const r = await fetch(`${API_URL}/steps?taskId=${task.id}`);
       setSteps(await r.json());
     } else {
       setSteps(steps.filter(s => s.id !== id));

--- a/frontend/forms/UserForm.js
+++ b/frontend/forms/UserForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TextInput, StyleSheet } from 'react-native';
 import HomeChoresFormComponent from '../components/HomeChoresFormComponent';
+import API_URL from '../api';
 
 export default function UserForm({ user, navigateBack }) {
   const editMode = !!user;
@@ -11,13 +12,13 @@ export default function UserForm({ user, navigateBack }) {
     const body = { name };
     if (password) body.password = password;
     if (editMode) {
-      await fetch(`http://localhost:3000/users/${user.id}`, {
+      await fetch(`${API_URL}/users/${user.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
     } else {
-      await fetch('http://localhost:3000/users', {
+      await fetch(`${API_URL}/users`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)

--- a/frontend/pages/CalendarPage.js
+++ b/frontend/pages/CalendarPage.js
@@ -5,6 +5,7 @@ import 'react-calendar/dist/Calendar.css';
 import '../styles/calendarOverrides.css';
 import {Calendar as BigCalendar} from 'react-native-big-calendar';
 import {LOCALE} from '../utils/config';
+import API_URL from '../api';
 
 export default function CalendarPage({ navigate, user, globalConfig }) {
     const [events, setEvents] = useState([]);
@@ -12,11 +13,11 @@ export default function CalendarPage({ navigate, user, globalConfig }) {
     const [selectedDate, setSelectedDate] = useState(null);
 
     useEffect(() => {
-        fetch('http://localhost:3000/events')
+        fetch(`${API_URL}/events`)
             .then(res => res.json())
             .then(setEvents)
             .catch(console.error);
-        fetch('http://localhost:3000/tasks')
+        fetch(`${API_URL}/tasks`)
             .then(res => res.json())
             .then(setTasks)
             .catch(console.error);

--- a/frontend/pages/DashboardPage.js
+++ b/frontend/pages/DashboardPage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import AppButton from '../components/AppButton';
 import EventTile from '../components/EventTile';
+import API_URL from '../api';
 
 
 /**
@@ -16,18 +17,18 @@ export default function DashboardPage({ user, navigate, setUser }) {
 
   useEffect(() => {
     if (!user) return;
-    fetch('http://localhost:3000/events')
+    fetch(`${API_URL}/events`)
       .then(res => res.json())
       .then(data => {
         const filtered = data.filter(ev => ev.assignedTo === user.id);
         setEvents(filtered);
       })
       .catch(() => {});
-    fetch('http://localhost:3000/tasks')
+    fetch(`${API_URL}/tasks`)
       .then(res => res.json())
       .then(setTasks)
       .catch(() => {});
-    fetch('http://localhost:3000/users')
+    fetch(`${API_URL}/users`)
       .then(res => res.json())
       .then(users => {
         const me = users.find(u => u.id === user.id);

--- a/frontend/pages/EventsPage.js
+++ b/frontend/pages/EventsPage.js
@@ -3,6 +3,7 @@ import { View, Text, FlatList, StyleSheet, Button } from 'react-native';
 import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
 import EventTile from '../components/EventTile';
+import API_URL from '../api';
 
 export default function EventsPage({ task, navigate, setNavigationGuard, user, setUser }) {
     const [events, setEvents] = useState([]);
@@ -10,7 +11,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
     const [tab, setTab] = useState('upcoming');
 
     const load = async () => {
-        const res = await fetch(`http://localhost:3000/events?taskId=${task.id}`);
+        const res = await fetch(`${API_URL}/events?taskId=${task.id}`);
         const data = await res.json();
         data.sort((a, b) => new Date(a.date) - new Date(b.date));
         setEvents(data);
@@ -42,7 +43,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
 
 
     const handleComplete = async (id) => {
-        await fetch(`http://localhost:3000/events/${id}`, {
+        await fetch(`${API_URL}/events/${id}`, {
             method: 'PATCH',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ state: 'completed' })
@@ -56,7 +57,7 @@ export default function EventsPage({ task, navigate, setNavigationGuard, user, s
     };
 
     const handleDelete = async (id) => {
-        await fetch(`http://localhost:3000/events/${id}`, { method: 'DELETE' });
+        await fetch(`${API_URL}/events/${id}`, { method: 'DELETE' });
         setProgressMap(pm => {
             const cp = { ...pm };
             delete cp[id];
@@ -123,7 +124,7 @@ function EventRow({ item, onComplete, onDelete, navigate, reportProgress, user, 
 
     useEffect(() => {
         const load = async () => {
-            const r = await fetch(`http://localhost:3000/steps?taskId=${item.taskId}`);
+            const r = await fetch(`${API_URL}/steps?taskId=${item.taskId}`);
             const data = await r.json();
             setSteps(data);
         };

--- a/frontend/pages/LoginPage.js
+++ b/frontend/pages/LoginPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, useWindowDimensions, ScrollView } from 'react-native';
 import { Text, TextInput, Button, Switch, Surface } from 'react-native-paper';
+import API_URL from '../api';
 
 export default function LoginPage({ onLogin }) {
   const [name, setName] = useState('');
@@ -10,7 +11,7 @@ export default function LoginPage({ onLogin }) {
   const isWide = width >= 500;
 
   const handleLogin = async () => {
-    const res = await fetch('http://localhost:3000/login', {
+    const res = await fetch(`${API_URL}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, password })

--- a/frontend/pages/SettingsPage.js
+++ b/frontend/pages/SettingsPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Button, StyleSheet, TextInput } from 'react-native';
 import { TimePickerModal } from 'react-native-paper-dates';
 import HomeChoresFormComponent from '../components/HomeChoresFormComponent';
+import API_URL from '../api';
 
 export default function SettingsPage({ user, setUser, navigate }) {
   const [start, setStart] = useState(user.config?.workingHoursStart || '06:00');
@@ -12,7 +13,7 @@ export default function SettingsPage({ user, setUser, navigate }) {
   const [showEnd, setShowEnd] = useState(false);
 
   const save = async () => {
-    await fetch(`http://localhost:3000/users/${user.id}/config`, {
+    await fetch(`${API_URL}/users/${user.id}/config`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/pages/TaskPage.js
+++ b/frontend/pages/TaskPage.js
@@ -4,16 +4,17 @@ import { IconButton } from 'react-native-paper';
 import Tile from '../components/Tile';
 import { TASK_COLOR } from '../utils/colors';
 import { formatDateLocal } from '../utils/config';
+import API_URL from '../api';
 
 export default function TaskPage({ navigate }) {
   const [tasks, setTasks] = useState([]);
   const [users, setUsers] = useState({});
 
   const load = async () => {
-    const res = await fetch('http://localhost:3000/tasks');
+    const res = await fetch(`${API_URL}/tasks`);
     const data = await res.json();
     setTasks(data);
-    const resUsers = await fetch('http://localhost:3000/users');
+    const resUsers = await fetch(`${API_URL}/users`);
     const userData = await resUsers.json();
     const map = {};
     userData.forEach(u => {
@@ -27,17 +28,17 @@ export default function TaskPage({ navigate }) {
   }, []);
 
   const handleDuplicate = async id => {
-    await fetch(`http://localhost:3000/tasks/${id}/duplicate`, { method: 'POST' });
+    await fetch(`${API_URL}/tasks/${id}/duplicate`, { method: 'POST' });
     load();
   };
 
   const handleDelete = async id => {
-    await fetch(`http://localhost:3000/tasks/${id}`, { method: 'DELETE' });
+    await fetch(`${API_URL}/tasks/${id}`, { method: 'DELETE' });
     load();
   };
 
   const handleCreateNow = async task => {
-    await fetch('http://localhost:3000/events', {
+    await fetch(`${API_URL}/events`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ taskId: task.id })

--- a/frontend/pages/UserPage.js
+++ b/frontend/pages/UserPage.js
@@ -4,12 +4,13 @@ import { IconButton } from 'react-native-paper';
 import AppButton from '../components/AppButton';
 import Tile from '../components/Tile';
 import { USER_COLOR } from '../utils/colors';
+import API_URL from '../api';
 
 export default function UserPage({ navigate }) {
   const [users, setUsers] = useState([]);
 
   const load = async () => {
-    const res = await fetch('http://localhost:3000/users');
+    const res = await fetch(`${API_URL}/users`);
     const data = await res.json();
     setUsers(data);
   };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Deal with your own chores with a point based system",
   "main": "frontend/index.js",
   "scripts": {
-    "start": "expo start",
+    "start": "node backend/server.js",
+    "dev": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
## Summary
- Read server port from `PORT` env var and expose backend via `npm start`
- Document Railway deployment steps and new frontend dev command
- Replace hardcoded API URLs in frontend with `EXPO_PUBLIC_API_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0cd568a28832faa241afcf8551360